### PR TITLE
Incorporating SVT alignment shifts

### DIFF
--- a/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/services/CVTReconstruction.java
+++ b/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/services/CVTReconstruction.java
@@ -108,8 +108,16 @@ public class CVTReconstruction extends ReconstructionEngine {
             boolean align=false;
             if(newRun>99)
                 align = true;
-                SVTStripFactory svtStripFactory = new SVTStripFactory( this.getSVTDB(), align );
-                SVTGeom.setSvtStripFactory(svtStripFactory);
+            
+		    //SVTConstants.VERBOSE = true;
+		    DatabaseConstantProvider cp = new DatabaseConstantProvider(newRun, "default");
+		    cp = SVTConstants.connect( cp );
+		    SVTConstants.loadAlignmentShifts( cp );
+		    cp.disconnect();    
+		    this.setSVTDB(cp);
+
+            SVTStripFactory svtStripFactory = new SVTStripFactory( this.getSVTDB(), align );
+            SVTGeom.setSvtStripFactory(svtStripFactory);
 
             this.setRun(newRun);
 
@@ -386,7 +394,7 @@ public class CVTReconstruction extends ReconstructionEngine {
 
     public boolean init() {
         System.out.println(" ........................................ trying to connect to db ");
-        CCDBConstantsLoader.Load(new DatabaseConstantProvider(10, "default"));
+        //CCDBConstantsLoader.Load(new DatabaseConstantProvider(10, "default"));
         
         DatabaseConstantProvider cp = new DatabaseConstantProvider(101, "default");
         cp = SVTConstants.connect( cp );

--- a/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/svt/Geometry.java
+++ b/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/svt/Geometry.java
@@ -12,6 +12,15 @@ import org.jlab.rec.cvt.trajectory.Helix;
 import org.jlab.detector.geant4.v2.SVT.*;
 import org.jlab.geometry.prim.Line3d;
 
+//gpg
+import org.jlab.detector.geant4.v2.SVT.SVTConstants;
+import org.jlab.detector.geant4.v2.SVT.SVTStripFactory;
+import org.jlab.detector.geant4.v2.SVT.AlignmentFactory;
+import org.jlab.rec.cvt.Constants;
+
+import org.jlab.geometry.prim.*;
+import org.jlab.geometry.prim.Line3d;
+
 public class Geometry {
 
     private SVTStripFactory _svtStripFactory;
@@ -69,7 +78,14 @@ public class Geometry {
                                                                               sector-1,
                                                                               SVTConstants.LAYERRADIUS[ rm[0] ][ rm[1]],
                                                                               SVTConstants.Z0ACTIVE[    rm[0] ] ));
-        return new Point3D(labFrameLine.origin().x, labFrameLine.origin().y, labFrameLine.origin().z);
+	// apply the shifts to both ends of labFrameLine
+	double scaleT = 1.0, scaleR = 1.0;// scale factors used for visualization. Not relevant here.
+	AlignmentFactory.applyShift(labFrameLine.origin(),SVTConstants.getDataAlignmentSectorShift()[SVTConstants.convertRegionSector2Index( rm[0],sector-1)], SVTAlignmentFactory.getIdealFiducialCenter( rm[0], sector-1),scaleT,scaleR );
+        AlignmentFactory.applyShift(labFrameLine.end(),   SVTConstants.getDataAlignmentSectorShift()[SVTConstants.convertRegionSector2Index( rm[0],sector-1)], SVTAlignmentFactory.getIdealFiducialCenter( rm[0], sector-1),scaleT,scaleR );
+
+	// return only the origin of the line.
+
+	return new Point3D(labFrameLine.origin().x, labFrameLine.origin().y, labFrameLine.origin().z);
 
       /* * * * * * * *
       // returns NPE:
@@ -88,6 +104,12 @@ public class Geometry {
                                                                               sector-1,
                                                                               SVTConstants.LAYERRADIUS[ rm[0] ][ rm[1]],
                                                                               SVTConstants.Z0ACTIVE[    rm[0] ] ));
+	// apply the shifts to both ends of labFrameLine
+	double scaleT = 1.0, scaleR = 1.0;// scale factors used for visualization. Not relevant here.
+	AlignmentFactory.applyShift(labFrameLine.origin(),SVTConstants.getDataAlignmentSectorShift()[SVTConstants.convertRegionSector2Index( rm[0],sector-1)], SVTAlignmentFactory.getIdealFiducialCenter( rm[0], sector-1),scaleT,scaleR );
+        AlignmentFactory.applyShift(labFrameLine.end(),   SVTConstants.getDataAlignmentSectorShift()[SVTConstants.convertRegionSector2Index( rm[0],sector-1)], SVTAlignmentFactory.getIdealFiducialCenter( rm[0], sector-1),scaleT,scaleR );
+
+	// return only the origin of this line.
         return new Point3D(labFrameLine.origin().x, labFrameLine.origin().y, labFrameLine.origin().z);
     }
 
@@ -209,6 +231,10 @@ public class Geometry {
                                                                                   //= SVTConstants.LAYERRADIUS[rm[0]][rm[1]]
                                                                                   SVTConstants.LAYERRADIUS[rm[0]][rm[1]]+gap/2,
                                                                                   SVTConstants.Z0ACTIVE[rm[0]] ));
+	    //gpg apply the shifts to both ends of labFrameLine.
+	    double scaleT = 1.0, scaleR = 1.0;// scale factors used for visualization. Not relevant here.
+	    AlignmentFactory.applyShift(labFrameLine.origin(),SVTConstants.getDataAlignmentSectorShift()[SVTConstants.convertRegionSector2Index( rm[0],sector-1)], SVTAlignmentFactory.getIdealFiducialCenter( rm[0], sector-1),scaleT,scaleR );
+	    AlignmentFactory.applyShift(labFrameLine.end(),   SVTConstants.getDataAlignmentSectorShift()[SVTConstants.convertRegionSector2Index( rm[0],sector-1)], SVTAlignmentFactory.getIdealFiducialCenter( rm[0], sector-1),scaleT,scaleR );
 
             transf= new Point3D(labFrameLine.origin().x,
                                 labFrameLine.origin().y,

--- a/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/svt/Geometry.java
+++ b/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/svt/Geometry.java
@@ -244,6 +244,12 @@ public class Geometry {
             Line3d glLine = new Line3d(new Vector3d(x,y,z),
                                        new Vector3d(x,y,z)) ;
             boolean flip = true;
+		
+	    //gpg need to apply the reverse survey shifts here.
+	    double scaleT = 1.0, scaleR = 1.0;// scale factors used for visualization. Not relevant here.
+	    AlignmentFactory.applyInverseShift( glLine.origin(), SVTConstants.getDataAlignmentSectorShift()[SVTConstants.convertRegionSector2Index( rm[0],sector-1 )], SVTAlignmentFactory.getIdealFiducialCenter( rm[0], sector-1 ), scaleT, scaleR );
+	    AlignmentFactory.applyInverseShift( glLine.end(), SVTConstants.getDataAlignmentSectorShift()[SVTConstants.convertRegionSector2Index( rm[0],sector-1 )], SVTAlignmentFactory.getIdealFiducialCenter( rm[0], sector-1 ), scaleT, scaleR );
+
             Line3d localLine = glLine.transformed(SVTConstants.getLabFrame( (int)((layer+1)/2) -1,
                                                                             sector-1,
                                                                             SVTConstants.LAYERRADIUS[rm[0]][rm[1]]+gap/2, 


### PR DESCRIPTION
Changes made so the SVT alignment shifts are properly applied in the reconstruction. The files modified are 

 common-tools/clas-jcsg/src/main/java/org/jlab/detector/geant4/v2/SVT/AlignmentFactory.java
 reconstruction/cvt/src/main/java/org/jlab/rec/cvt/services/CVTReconstruction.java
 reconstruction/cvt/src/main/java/org/jlab/rec/cvt/svt/Geometry.java

A new method applyInverseShift was written and others applied in different places in the code especially transformToFrame in Geometry.java.

Details on testing and such can be found here

https://facultystaff.richmond.edu/~ggilfoyl/research/align31.pdf

The SVT geometry is documented in CLAS12-NOTE 2017-008.