### PR TITLE
CRITICAL: LTCC side now correctly detected

### DIFF
--- a/reconstruction/ltcc/src/main/java/org/jlab/service/ltcc/LTCCHit.java
+++ b/reconstruction/ltcc/src/main/java/org/jlab/service/ltcc/LTCCHit.java
@@ -81,8 +81,8 @@ public final class LTCCHit {
     
     LTCCHit(DataBank bank, int index, IndexedTable gain, IndexedTable timing_offset) {
        this.sector = bank.getByte("sector", index);
-       this.side = bank.getByte("layer", index);
        this.segment = bank.getShort("component", index);
+       this.side = bank.getByte("order", index);
        this.adc = bank.getInt("ADC", index);
        this.rawTime = bank.getFloat("time", index);
        //this.pedestal = bank.getShort("ped", index);

--- a/reconstruction/ltcc/src/main/java/org/jlab/service/ltcc/viewer/LTCCClusterHistos.java
+++ b/reconstruction/ltcc/src/main/java/org/jlab/service/ltcc/viewer/LTCCClusterHistos.java
@@ -4,7 +4,7 @@
  * and open the template in the editor.
  */
 package org.jlab.service.ltcc.viewer;
-import org.jlab.service.ltcc.viewer.LTCCHistogrammer;
+
 import org.jlab.groot.data.H1F;
 import org.jlab.service.ltcc.LTCCCluster;
 

--- a/reconstruction/ltcc/src/main/java/org/jlab/service/ltcc/viewer/LTCCClusterHistos.java
+++ b/reconstruction/ltcc/src/main/java/org/jlab/service/ltcc/viewer/LTCCClusterHistos.java
@@ -3,8 +3,10 @@
  * To change this template file, choose Tools | Templates
  * and open the template in the editor.
  */
-package org.jlab.service.ltcc;
+package org.jlab.service.ltcc.viewer;
+import org.jlab.service.ltcc.viewer.LTCCHistogrammer;
 import org.jlab.groot.data.H1F;
+import org.jlab.service.ltcc.LTCCCluster;
 
 
 /**

--- a/reconstruction/ltcc/src/main/java/org/jlab/service/ltcc/viewer/LTCCHistogrammer.java
+++ b/reconstruction/ltcc/src/main/java/org/jlab/service/ltcc/viewer/LTCCHistogrammer.java
@@ -3,10 +3,12 @@
  * To change this template file, choose Tools | Templates
  * and open the template in the editor.
  */
-package org.jlab.service.ltcc;
+package org.jlab.service.ltcc.viewer;
 import java.util.Map;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.function.Function;
+import java.util.List;
+import java.util.stream.Collectors;
 import javafx.util.Pair;
 import org.jlab.groot.data.H1F;
 import org.jlab.groot.data.H2F;
@@ -39,8 +41,8 @@ public class LTCCHistogrammer<DataType> {
     private final Map<String, SmartHisto<H2F, Pair<Double, Double>>> histos2D;
     
     LTCCHistogrammer() {
-        histos1D = new HashMap();
-        histos2D = new HashMap();
+        histos1D = new LinkedHashMap();
+        histos2D = new LinkedHashMap();
     }
     
     public void add(H1F histo, Function<DataType, Double> getter) {
@@ -65,5 +67,17 @@ public class LTCCHistogrammer<DataType> {
     }
     public H2F getH2F(String name) {
         return histos2D.get(name).getHisto();
+    }
+    public List<H1F> getH1Fs() {
+        return histos1D.values()
+                .stream()
+                .map(SmartHisto::getHisto)
+                .collect(Collectors.toList());
+    }
+    public List<H2F> getH2Fs() {
+        return histos2D.values()
+                .stream()
+                .map(SmartHisto::getHisto)
+                .collect(Collectors.toList());
     }
 }

--- a/reconstruction/ltcc/src/main/java/org/jlab/service/ltcc/viewer/LTCCHitHistos.java
+++ b/reconstruction/ltcc/src/main/java/org/jlab/service/ltcc/viewer/LTCCHitHistos.java
@@ -3,8 +3,10 @@
  * To change this template file, choose Tools | Templates
  * and open the template in the editor.
  */
-package org.jlab.service.ltcc;
+package org.jlab.service.ltcc.viewer;
+import org.jlab.service.ltcc.viewer.LTCCHistogrammer;
 import org.jlab.groot.data.H1F;
+import org.jlab.service.ltcc.LTCCHit;
 
 
 /**
@@ -23,7 +25,7 @@ public class LTCCHitHistos extends LTCCHistogrammer<LTCCHit> {
         hsegment.setFillColor(34);
         this.add(hsegment, hit -> (double) hit.getSegment());
         
-        H1F hside = new H1F("side", "side", "#", 2, 0, 2);
+        H1F hside = new H1F("side", "side", "#", 5, 0, 5);
         hside.setFillColor(37);
         this.add(hside, hit -> (double) hit.getSide());
         

--- a/reconstruction/ltcc/src/main/java/org/jlab/service/ltcc/viewer/LTCCViewer.java
+++ b/reconstruction/ltcc/src/main/java/org/jlab/service/ltcc/viewer/LTCCViewer.java
@@ -1,4 +1,4 @@
-package org.jlab.service.ltcc;
+package org.jlab.service.ltcc.viewer;
 
 import org.jlab.io.base.DataEvent;
 import org.jlab.io.base.DataSource;
@@ -10,6 +10,9 @@ import org.jlab.groot.graphics.EmbeddedCanvas;
 import org.jlab.groot.graphics.EmbeddedCanvasTabbed;
 import org.jlab.groot.base.GStyle;
 import org.jlab.groot.group.DataGroup;
+import org.jlab.groot.data.H1F;
+import org.jlab.service.ltcc.LTCCCluster;
+import org.jlab.service.ltcc.LTCCHit;
 
 
 
@@ -61,25 +64,21 @@ public class LTCCViewer {
     }
     
      private void drawClusters(EmbeddedCanvas canvas) {
-        canvas.divide(3, 2);
-        DataGroup hgroup = new DataGroup(3,2);
-        hgroup.addDataSet(clusterHistos.getH1F("sector"), 0);
-        hgroup.addDataSet(clusterHistos.getH1F("segment"), 1);
-        hgroup.addDataSet(clusterHistos.getH1F("nHits"), 3);
-        hgroup.addDataSet(clusterHistos.getH1F("nphe"), 4);
-        hgroup.addDataSet(clusterHistos.getH1F("theta"), 2);
-        hgroup.addDataSet(clusterHistos.getH1F("phi"), 5);
+        canvas.divide(3, 3);
+        DataGroup hgroup = new DataGroup(3, 3);
+        int idx = 0;
+        for(H1F h : clusterHistos.getH1Fs()) {
+            hgroup.addDataSet(h, idx++);
+        }
         canvas.draw(hgroup);
     }
     private void drawHits(EmbeddedCanvas canvas) {
-        canvas.divide(3, 2);
-        DataGroup hgroup = new DataGroup(3,2);
-        hgroup.addDataSet(hitHistos.getH1F("sector"), 0);
-        hgroup.addDataSet(hitHistos.getH1F("segment"), 1);
-        hgroup.addDataSet(hitHistos.getH1F("adc"), 3);
-        hgroup.addDataSet(hitHistos.getH1F("nphe"), 4);
-        hgroup.addDataSet(hitHistos.getH1F("theta"), 2);
-        hgroup.addDataSet(hitHistos.getH1F("phi"), 5);
+        canvas.divide(3, 3);
+        DataGroup hgroup = new DataGroup(3, 3);
+        int idx = 0;
+        for(H1F h : hitHistos.getH1Fs()) {
+            hgroup.addDataSet(h, idx++);
+        }
         canvas.draw(hgroup);
     }
     
@@ -97,13 +96,17 @@ public class LTCCViewer {
      * @param args ignored
      */
     public static void main(String[] args) {
-        String inputfile = "/Users/sly2j/Dropbox/Work/JLab-CLAS12/clas12-ltcc/sylvester/rec/20170123/coatjava/rec.hipo";
+        String inputfile = "/Users/sly2j/Data/CLAS12/pass0_4/out_clas_002053.evio.1.hipo";
 
         DataSource reader = new HipoDataSource();
         reader.open(inputfile);
        
         LTCCViewer viewer = new LTCCViewer();
         
+        // dump the first 10 events
+        for (int i = 0; i < 1; ++i) {
+            reader.getNextEvent().getBank("LTCC::adc").show();
+        }
         while (reader.hasEvent()) {
             viewer.process(reader.getNextEvent());
         }


### PR DESCRIPTION
Each LTCC PMT has 3 unique identifiers: (sector, segment, side). This used to be encoded in the (sector, component, layer) fields, but was recently changed to be (sector, component, order) instead in the decoded data files. This pull requests updates the LTCC reconstruction code to reflect these changes. It also includes a minor refactoring of the LTCC reconstuction debug viewer.

Note regarding simulation:
I'm unsure if the EVIO-HIPO converter was updated for this change, meaning that there might be an issue when converting GEMC-generated EVIO files 
(See clas-reco/src/main/java/org/jlab/clas/reco/io/EvioHipoEvent.java line 143)
hipoBank.setByte("layer", i, (byte) evioBank.getInt("side",i));