### PR TITLE
Rename identical item names in track banks

### DIFF
--- a/etc/bankdefs/hipo/EVENT.json
+++ b/etc/bankdefs/hipo/EVENT.json
@@ -158,7 +158,7 @@
             {"name":"vz_nomm",      "id":13, "type":"float", "info":"z component of the vertex"},
             {"name":"chi2_nomm",    "id":14, "type":"float", "info":"Chi2 (or quality) track fitting"},
             {"name":"NDF_nomm",     "id":15, "type":"int16", "info":"number of degrees of freedom in track fitting with no MM"},
-            {"name":"status",       "id":16, "type":"int16", "info":"hit status"}
+            {"name":"hit_status",       "id":16, "type":"int16", "info":"hit status"}
         ]
     },
     {
@@ -339,7 +339,7 @@
             {"name":"vz_nomm",      "id":13, "type":"float", "info":"z component of the vertex"},
             {"name":"chi2_nomm",    "id":14, "type":"float", "info":"Chi2 (or quality) track fitting"},
             {"name":"NDF_nomm",     "id":15, "type":"int16", "info":"number of degrees of freedom in track fitting with no MM"},
-            {"name":"status",       "id":16, "type":"int16", "info":"hit status"}
+            {"name":"hit_status",       "id":16, "type":"int16", "info":"hit status"}
         ]
     },
     {


### PR DESCRIPTION
Both the "status of the track" and "hit status" have the same name "status".