### PR TITLE
EC/CTOF/FTOFEngine:  handle RUN::config.run=0 more gracefully

### DIFF
--- a/reconstruction/ec/src/main/java/org/jlab/service/ec/ECEngine.java
+++ b/reconstruction/ec/src/main/java/org/jlab/service/ec/ECEngine.java
@@ -34,7 +34,7 @@ public class ECEngine extends ReconstructionEngine {
     public Boolean singleEvent = false;
     public Boolean        isMC = false;
     int                 calrun = 2;
-    
+
     public ECEngine(){
         super("EC","gavalian","1.0");
     }
@@ -44,12 +44,15 @@ public class ECEngine extends ReconstructionEngine {
            
         ECCommon.debug       = this.debug;
         ECCommon.singleEvent = this.singleEvent;
+
         int runNo = 10;
-        //System.out.println(" PROCESSING EC EVENT ");
         if(de.hasBank("RUN::config")==true){
             DataBank bank = de.getBank("RUN::config");
             runNo = bank.getInt("run", 0);
-            //System.out.println("------- The bank exists. run = " + runNo );
+            if (runNo<=0) {
+                System.err.println("ECEngine:  got run <= 0 in RUN::config, skipping event.");
+                return false;
+            }
         }
     
         

--- a/reconstruction/tof/src/main/java/org/jlab/service/ctof/CTOFEngine.java
+++ b/reconstruction/tof/src/main/java/org/jlab/service/ctof/CTOFEngine.java
@@ -70,15 +70,19 @@ public class CTOFEngine extends ReconstructionEngine {
     public boolean processDataEvent(DataEvent event) {
         //setRunConditionsParameters( event) ;
         if(event.hasBank("RUN::config")==false ) {
-		System.err.println("RUN CONDITIONS NOT READ!");
-		return true;
-	}
-		
+            System.err.println("RUN CONDITIONS NOT READ!");
+            return true;
+        }
+
         DataBank bank = event.getBank("RUN::config");
 		
         // Load the constants
         //-------------------
-        int newRun = bank.getInt("run", 0);
+        final int newRun = bank.getInt("run", 0);
+        if (newRun<=0) {
+            System.err.println("CTOFEngine:  got run <= 0 in RUN::config, skipping event.");
+            return false;
+        }
 
         if (geometry == null) {
             System.err.println(" CTOF Geometry not loaded !!!");

--- a/reconstruction/tof/src/main/java/org/jlab/service/ftof/FTOFEngine.java
+++ b/reconstruction/tof/src/main/java/org/jlab/service/ftof/FTOFEngine.java
@@ -109,7 +109,10 @@ public class FTOFEngine extends ReconstructionEngine {
         // Load the constants
         //-------------------
         int newRun = bank.getInt("run", 0);
-
+        if (newRun<=0) {
+            System.err.println("FTOFEngine:  got run <= 0 in RUN::config, skipping event.");
+            return false;
+        }
         
         if (geometry == null) {
             System.err.println(" FTOF Geometry not loaded !!!");


### PR DESCRIPTION
If run<=0, print message and ignore event, instead of generating less informative errors (e.g. from ConstantsManager.getConstants).

This happens at the beginning of real data runs before raw header banks get filled properly.

Other engines may have similar "issues", but behavior depends on run ranges populated in ccdb for each system.