### PR TITLE
eb:  use RUN::config.run for ccdb

### DIFF
--- a/reconstruction/eb/src/main/java/org/jlab/rec/eb/EBCCDBConstants.java
+++ b/reconstruction/eb/src/main/java/org/jlab/rec/eb/EBCCDBConstants.java
@@ -15,7 +15,8 @@ import org.jlab.geom.prim.Vector3D;
  */
 public class EBCCDBConstants {
 
-    public static boolean LOADED = false;
+    private static int currentRun = -1;
+    private static boolean isLoaded = false;
     
     private static final String ebTablePrefix="/calibration/eb/";
 
@@ -36,6 +37,8 @@ public class EBCCDBConstants {
     
     private static final String[] otherTableNames={
         "/geometry/target",
+        "/calibration/ftof/tres",
+        //"/calibration/ctof/tres"
     };
 
     public static List <String> getAllTableNames() {
@@ -50,8 +53,6 @@ public class EBCCDBConstants {
     private static Map <EBCCDBEnum,Integer> dbIntegers = new HashMap<EBCCDBEnum,Integer>();
     private static Map <EBCCDBEnum,Vector3D> dbVector3Ds = new HashMap<EBCCDBEnum,Vector3D>();
     private static Map <EBCCDBEnum,Double[]> dbArrays = new HashMap<EBCCDBEnum,Double[]>();
-
-    private static EBDatabaseConstantProvider DBP = new EBDatabaseConstantProvider(10,"default");
 
     // fill maps:
     private static synchronized void setDouble(EBCCDBEnum key,Double value) {
@@ -87,6 +88,11 @@ public class EBCCDBConstants {
         if (!dbArrays.containsKey(key)) 
             throw new RuntimeException("Missing Integer Key:  "+key);
         return dbArrays.get(key);
+    }
+
+    public static synchronized IndexedTable getTable(String tableName) {
+        if (tables.containsKey(tableName)) return tables.get(tableName);
+        else return null;
     }
 
     // read ccdb tables:
@@ -236,13 +242,13 @@ public class EBCCDBConstants {
         
         //loadDouble(EBCCDBEnum.TRIGGER_ID,
 
-        LOADED = true;
-        setDB(DBP);
+        currentRun = run;
+        isLoaded = true;
+        //setDB(DBP);
 
         System.out.println("EBCCDBConstants:  loaded run "+run);
     }
     
-    private static EBDatabaseConstantProvider DB;
-    public static final EBDatabaseConstantProvider getDB() { return DB; }
-    public static final void setDB(EBDatabaseConstantProvider db) { DB=db; }
+    public static synchronized boolean isLoaded() { return isLoaded; }
+    public static synchronized int getRunNumber() { return currentRun; }
 }

--- a/reconstruction/eb/src/main/java/org/jlab/rec/eb/EBUtil.java
+++ b/reconstruction/eb/src/main/java/org/jlab/rec/eb/EBUtil.java
@@ -2,6 +2,7 @@ package org.jlab.rec.eb;
 
 import static java.lang.Math.abs;
 import static java.lang.Math.pow;
+import org.jlab.clas.detector.ScintillatorResponse;
 import org.jlab.clas.detector.DetectorResponse;
 import org.jlab.clas.detector.DetectorParticle;
 import org.jlab.detector.base.DetectorType;
@@ -62,9 +63,9 @@ public class EBUtil {
     }
 
     /**
-     * Calculate timing resolution:
+     * Calculate timing resolution from EventBuilder constants:
      */
-    public static double getDetTimingResolution(DetectorParticle p, DetectorType type, int layer) {
+    public static double getEBTimingResolution(DetectorParticle p, DetectorType type, int layer) {
         Double[] pars;
         if (type==DetectorType.FTOF) {
             if (layer==1) pars=EBCCDBConstants.getArray(EBCCDBEnum.FTOF1A_TimingRes);
@@ -81,6 +82,27 @@ public class EBUtil {
         return res;
     }
 
+    /**
+     * Get timing resolution from detector calibration constants:
+     */
+    public static double getDetTimingResolution(ScintillatorResponse resp,int run) {
+        final int sector = resp.getDescriptor().getSector();
+        final int layer = resp.getDescriptor().getLayer();
+        final int component = resp.getDescriptor().getComponent();
+        String tableName=null;
+        if (resp.getDescriptor().getType()==DetectorType.FTOF) {
+            tableName="/calibration/ftof/tres";
+        }
+        else {
+            throw new RuntimeException("not ready for non-FTOF");
+        }
+        return EBCCDBConstants.getTable(tableName).
+            getDoubleValue("tres",sector,layer,component);
+    }
+
+    /**
+     * Calculate beta for given detector type:
+     */
     public static double getNeutralBeta(DetectorParticle p, DetectorType type, int layer,double startTime) {
         double beta=-1;
         DetectorResponse resp = p.getResponse(type,layer);
@@ -91,6 +113,10 @@ public class EBUtil {
         }
         return beta;
     }
+
+    /**
+     * Calculate beta for ECAL, prioritized by layer:
+     */
     public static double getNeutralBetaECAL(DetectorParticle p, double startTime) {
         double      beta = getNeutralBeta(p,DetectorType.ECAL,1,startTime);
         if (beta<0) beta = getNeutralBeta(p,DetectorType.ECAL,4,startTime);


### PR DESCRIPTION
In support of upcoming run-dependent RF calibrations.

Note, usage of EventBuilder outside the standard service chain will now require choosing a valid run number and calling `EBEngine.init(int run)` instead of `EBEngine.init()`.  Previously the default run number was 10.