### PR TITLE
CTOF geometry: update of key geometry parameters and fixed offset calculation in reco

### DIFF
--- a/common-tools/clas-jcsg/src/main/java/org/jlab/detector/geant4/v2/CTOFGeant4Factory.java
+++ b/common-tools/clas-jcsg/src/main/java/org/jlab/detector/geant4/v2/CTOFGeant4Factory.java
@@ -58,13 +58,21 @@ public final class CTOFGeant4Factory extends Geant4Factory {
 
         private Line3d centerline;
         private final double angle0 = 3.75, dangle = 7.5;
-        private final double zmin = -54.18, zmax = 36.26;
+        private final double radius = 25.11;
+        private final double thickness = 3.0266;
+        private final double lengthOdd = 88.9328;
+        private final double offsetOdd = -8.9935;
+        private final double lengthEven = 88.0467;
+        private final double offsetEven = -8.2111;
+        
+//        private final double zmin = -54.18, zmax = 36.26;
 
         CTOFpaddle(String name, InputStream stlstream, int padnum) {
             super(name, stlstream);
-            Vector3d cent = new Vector3d(26.62,0, 0);
+            Vector3d cent = new Vector3d(radius+thickness/2.,0, 0);
             cent.rotateZ(Math.toRadians(angle0 + (padnum - 1) * dangle));
-            centerline = new Line3d(new Vector3d(cent.x, cent.y, zmin), new Vector3d(cent.x, cent.y, zmax));
+            if(padnum%2==0) centerline = new Line3d(new Vector3d(cent.x, cent.y, -lengthEven/2+offsetEven), new Vector3d(cent.x, cent.y, lengthEven/2+offsetEven));
+            else            centerline = new Line3d(new Vector3d(cent.x, cent.y, -lengthOdd/2+offsetOdd), new Vector3d(cent.x, cent.y, lengthOdd/2+offsetOdd));
         }
 
         @Override

--- a/common-tools/clas-jcsg/src/main/java/org/jlab/detector/geant4/v2/CTOFGeant4Factory.java
+++ b/common-tools/clas-jcsg/src/main/java/org/jlab/detector/geant4/v2/CTOFGeant4Factory.java
@@ -61,9 +61,9 @@ public final class CTOFGeant4Factory extends Geant4Factory {
         private final double radius = 25.11;
         private final double thickness = 3.0266;
         private final double lengthOdd = 88.9328;
-        private final double offsetOdd = -8.9935;
+        private final double offsetOdd = -8.9874;
         private final double lengthEven = 88.0467;
-        private final double offsetEven = -8.2111;
+        private final double offsetEven = -8.5031;
         
 //        private final double zmin = -54.18, zmax = 36.26;
 

--- a/reconstruction/tof/src/main/java/org/jlab/rec/ctof/Constants.java
+++ b/reconstruction/tof/src/main/java/org/jlab/rec/ctof/Constants.java
@@ -18,7 +18,7 @@ public class Constants {
 
     public static final double[] SCBARTHICKN = new double[1]; // 3 cm
     //public static final double LSBCONVFAC = 24. / 1000.; // ns/bin
-    public static final double[] ADC_MIP = new double[1]; // From DB 800
+//    public static final double[] ADC_MIP = new double[1]; // From DB 800
     public static final double DEDX_MIP = 1.956; // ~2 MeV/g/cm^2
     public static final double[] PEDU = new double[1]; // L pedestal
     public static final double[] PEDD = new double[1]; // R pedestal
@@ -50,14 +50,14 @@ public class Constants {
     // parameter for
     // coord z
 
-    public static final double DYHL = 0.8861; // Shift along beam line between
-    // high and the low pitch angles
-    // counters
-    // public static final double PCO = 19.4160; // Constant put the center of
-    // the CTOF barrel in its design position
-    public static final double PCO = 10.0; // Constant put the center of the
-    // CTOF barrel in its design
-    // position according to GEMC
+//    public static final double DYHL = 0.8861; // Shift along beam line between
+//    // high and the low pitch angles
+//    // counters
+//    // public static final double PCO = 19.4160; // Constant put the center of
+//    // the CTOF barrel in its design position
+//    public static final double PCO = 10.0; // Constant put the center of the
+//    // CTOF barrel in its design
+//    // position according to GEMC
 
     public static double CLSMATCHXPAR = 1; // x-matching parameter between
     // panels 1a and 1b
@@ -95,7 +95,7 @@ public class Constants {
 
         SCBARTHICKN[0] = 3.02;
 
-        ADC_MIP[0] = 800;
+//        ADC_MIP[0] = 800;
 
         TRKMATCHXPAR[0] = 1; // some reasonable value needs to be put there
         TRKMATCHYPAR[0] = 1; // some reasonable value needs to be put there

--- a/reconstruction/tof/src/main/java/org/jlab/rec/tof/banks/ctof/HitReader.java
+++ b/reconstruction/tof/src/main/java/org/jlab/rec/tof/banks/ctof/HitReader.java
@@ -50,7 +50,8 @@ public class HitReader implements IMatchedHit {
             IndexedTable constants1, 
             IndexedTable constants2, 
             IndexedTable constants3, 
-            IndexedTable constants4) {
+            IndexedTable constants4, 
+            IndexedTable constants5) {
         /*
         0: "/calibration/ctof/attenuation"),
         1: "/calibration/ctof/effective_velocity"),
@@ -128,7 +129,8 @@ public class HitReader implements IMatchedHit {
             hit.set_HitParameters(1,  constants0, 
              constants1, 
              constants2, 
-             constants3);
+             constants3, 
+             constants5);
             // DetHits.get(hit.get_Panel()-1).add(hit);
         }
         // List<Hit> unique_hits = this.removeDuplicatedHits(updated_hits);

--- a/reconstruction/tof/src/main/java/org/jlab/rec/tof/hit/ctof/Hit.java
+++ b/reconstruction/tof/src/main/java/org/jlab/rec/tof/hit/ctof/Hit.java
@@ -148,23 +148,22 @@ public class Hit extends AHit implements IGetCalibrationParams {
 
     private Point3D calc_hitPosition() {
         Point3D hitPosition = new Point3D();
-        Vector3D dir = new Vector3D(this.get_paddleLine().end().x()
-                - this.get_paddleLine().origin().x(), this.get_paddleLine()
-                .end().y()
-                - this.get_paddleLine().origin().y(), this.get_paddleLine()
-                .end().z()
-                - this.get_paddleLine().origin().z());
-        dir.unit();
+//        Vector3D dir = new Vector3D(this.get_paddleLine().end().x()
+//                - this.get_paddleLine().origin().x(), this.get_paddleLine()
+//                .end().y()
+//                - this.get_paddleLine().origin().y(), this.get_paddleLine()
+//                .end().z()
+//                - this.get_paddleLine().origin().z());
+//        dir.unit();
         Point3D startpoint = this.get_paddleLine().origin();
         // double L_2 = this.get_paddleLine().length()/2;
         // hitPosition.setX(startpoint.x() + (L_2+this.get_y())*dir.x());
         // hitPosition.setY(startpoint.y() + (L_2+this.get_y())*dir.y());
         // hitPosition.setZ(startpoint.z() + (L_2+this.get_y())*dir.z());
-        hitPosition.setX(startpoint.x() + Constants.SCBARTHICKN[0] / 2
-                * dir.x());
-        hitPosition.setY(startpoint.y() + Constants.SCBARTHICKN[0] / 2
-                * dir.y());
+        hitPosition.setX(startpoint.x());
+        hitPosition.setY(startpoint.y());
         hitPosition.setZ(this.get_y());
+//        System.out.println(hitPosition.x() + " " + hitPosition.y() + " " +hitPosition.z() + " " + Constants.SCBARTHICKN[0]);
 
         return hitPosition;
     }
@@ -273,13 +272,14 @@ public class Hit extends AHit implements IGetCalibrationParams {
     public double yOffset(IndexedTable tab) {
         //double ccdbOffset = CCDBConstants.getYOFF()[this.get_Sector() - 1][this
         //        .get_Panel() - 1][this.get_Paddle() - 1];
-        double ccdbOffset =  tab.getDoubleValue("y_offset", this.get_Sector(),this.get_Panel(),this.get_Paddle());
-        double shift = Constants.DYHL;
-        if (this.get_Paddle() % 2 == 1) {
-            shift = 0;
-        }
-        double paddleCenteringOffset = Constants.PCO;
-        return ccdbOffset - shift + paddleCenteringOffset;
+//        double ccdbOffset =  tab.getDoubleValue("y_offset", this.get_Sector(),this.get_Panel(),this.get_Paddle());
+//        double shift = Constants.DYHL;
+//        if (this.get_Paddle() % 2 == 1) {
+//            shift = 0;
+//        }
+//        double paddleCenteringOffset = Constants.PCO;
+//        return ccdbOffset - shift + paddleCenteringOffset;
+        return -(this.get_paddleLine().origin().z()+this.get_paddleLine().end().z())/2;
     }
 
     @Override

--- a/reconstruction/tof/src/main/java/org/jlab/rec/tof/hit/ctof/Hit.java
+++ b/reconstruction/tof/src/main/java/org/jlab/rec/tof/hit/ctof/Hit.java
@@ -29,7 +29,7 @@ public class Hit extends AHit implements IGetCalibrationParams {
     }
 
     private Line3D _paddleLine; // paddle line
-
+    
     private CTOFDetHit _matchedTrackHit; // matched hit information from
     // tracking; this contains the
     // information of the entrance and
@@ -67,7 +67,8 @@ public class Hit extends AHit implements IGetCalibrationParams {
             IndexedTable constants0, 
             IndexedTable constants1, 
             IndexedTable constants2, 
-            IndexedTable constants3) {
+            IndexedTable constants3, 
+            IndexedTable constants5) {
         /*
         0: "/calibration/ctof/attenuation"),
         1: "/calibration/ctof/effective_velocity"),
@@ -106,8 +107,8 @@ public class Hit extends AHit implements IGetCalibrationParams {
         double ADCDErr = this.ADC2Unc();
         double TDCUErr = this.TDC1Unc();
         double TDCDErr = this.TDC2Unc();
-        double ADC_MIP = this.ADC_MIP(null);
-        double ADC_MIPErr = this.ADC_MIPUnc(null);
+        double ADC_MIP = this.ADC_MIP(constants5);
+        double ADC_MIPErr = this.ADC_MIPUnc(constants5);
         double DEDX_MIP = this.DEDX_MIP();
         double ScinBarThickn = this.ScinBarThickn();
 
@@ -386,12 +387,14 @@ public class Hit extends AHit implements IGetCalibrationParams {
 
     @Override
     public double ADC_MIP(IndexedTable tab) {
-        return Constants.ADC_MIP[this.get_Panel() - 1];
+//        return Constants.ADC_MIP[this.get_Panel() - 1];
+        return tab.getDoubleValue("mipa_upstream", this.get_Sector(),this.get_Panel(),this.get_Paddle());
     }
 
     @Override
     public double ADC_MIPUnc(IndexedTable tab) {
-        return Constants.ADC_MIP_UNC[this.get_Panel() - 1];
+//        return Constants.ADC_MIP_UNC[this.get_Panel() - 1];
+        return tab.getDoubleValue("mipa_upstream_err", this.get_Sector(),this.get_Panel(),this.get_Paddle());
     }
 
     @Override

--- a/reconstruction/tof/src/main/java/org/jlab/service/ctof/CTOFEngine.java
+++ b/reconstruction/tof/src/main/java/org/jlab/service/ctof/CTOFEngine.java
@@ -55,6 +55,7 @@ public class CTOFEngine extends ReconstructionEngine {
                     "/calibration/ctof/time_offsets",
                     "/calibration/ctof/tdc_conv",
                     "/calibration/ctof/status",
+                    "/calibration/ctof/gain_balance"
                 };
         
         requireConstants(Arrays.asList(ftofTables));
@@ -104,7 +105,8 @@ public class CTOFEngine extends ReconstructionEngine {
             this.getConstantsManager().getConstants(newRun, "/calibration/ctof/effective_velocity"),
             this.getConstantsManager().getConstants(newRun, "/calibration/ctof/time_offsets"),
             this.getConstantsManager().getConstants(newRun, "/calibration/ctof/tdc_conv"),
-            this.getConstantsManager().getConstants(newRun, "/calibration/ctof/status"));
+            this.getConstantsManager().getConstants(newRun, "/calibration/ctof/status"),
+            this.getConstantsManager().getConstants(newRun, "/calibration/ctof/gain_balance"));
 
         // 1) get the hits
         List<Hit> CTOFHits = hitRead.get_CTOFHits();


### PR DESCRIPTION
- update key geometry parameter values in jcsg to match latest values from CAD
- removed hardcoded geometry parameters in reco package, now using only info from jcsg geometry
- corrected calculation of y_offset in reco (longitudinal offset of the ctof paddle with respect to CLAS12 paddle)
 