### PR TITLE
Reorganization of magnetic field maps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,7 @@ common-tools/cnuphys/coatjava/etc/data/magfield/clas12-fieldmap-solenoid.dat
 common-tools/cnuphys/coatjava/etc/data/magfield/clas12-fieldmap-torus.dat
 common-tools/cnuphys/magfieldC/data/clas12_torus_fieldmap_binary.dat
 common-tools/cnuphys/magfieldC/data/solenoid-srr.dat
-etc/data/magfield/clas12-fieldmap-solenoid.dat
-etc/data/magfield/clas12-fieldmap-torus.dat
+etc/data/magfield/*.dat
 
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/

--- a/bin/decoder
+++ b/bin/decoder
@@ -1,16 +1,7 @@
-#!/bin/sh -f
+#!/bin/bash
 
-# This doesn't work in Travis.
-# Probably a shell issue (sh is dash in Travis).
-#source `dirname $0`/env.sh 
-
-SCRIPT_DIR=`dirname $0`
-DISTRO_DIR=$SCRIPT_DIR/../ ; export DISTRO_DIR
-CLAS12DIR=$SCRIPT_DIR/../ ; export CLAS12DIR
-CLARA_SERVICES=$DISTRO_DIR/lib/services; export CLARA_SERVICES
-DATAMINING=$DISTRO_DIR ; export DATAMINING
-TORUSMAP=clas12-fieldmap-torus.dat ; export TORUSMAP
-SOLENOIDMAP=clas12-fieldmap-solenoid.dat ; export SOLENOIDMAP
+# This doesn't work in dash (Travis's /bin/sh):
+source `dirname $0`/env.sh 
 
 MALLOC_ARENA_MAX=1; export MALLOC_ARENA_MAX
 

--- a/bin/env.sh
+++ b/bin/env.sh
@@ -1,10 +1,10 @@
-#!/bin/sh -f
+#!/bin/bash
 
 SCRIPT_DIR=`dirname $0`
 DISTRO_DIR=$SCRIPT_DIR/../ ; export DISTRO_DIR
 CLAS12DIR=$SCRIPT_DIR/../ ; export CLAS12DIR
 CLARA_SERVICES=$DISTRO_DIR/lib/services; export CLARA_SERVICES
 DATAMINING=$DISTRO_DIR ; export DATAMINING
-TORUSMAP=clas12-fieldmap-torus.dat ; export TORUSMAP
-SOLENOIDMAP=clas12-fieldmap-solenoid.dat ; export SOLENOIDMAP
+TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat ; export TORUSMAP
+SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_2008.dat ; export SOLENOIDMAP
 

--- a/build-coatjava.sh
+++ b/build-coatjava.sh
@@ -17,13 +17,20 @@ do
 done
 
 if [ $downloadMaps == "yes" ]; then
-  wget http://github.com/JeffersonLab/clas12-offline-resources/archive/field-maps.zip
-  unzip field-maps.zip
-  mkdir etc/data/magfield common-tools/cnuphys/coatjava/etc/data/magfield common-tools/cnuphys/magfieldC/data
-  mv clas12-offline-resources-field-maps/etc/* etc/data/magfield/
-  mv clas12-offline-resources-field-maps/cnuphys/* common-tools/cnuphys/coatjava/etc/data/magfield/
-  mv clas12-offline-resources-field-maps/cnuphysC/* common-tools/cnuphys/magfieldC/data/
-  rm -rf field-maps.zip clas12-offline-resources-field-maps
+  webDir=http://clasweb.jlab.org/clas12offline/magfield
+  locDir=etc/data/magfield
+  mkdir -p $locDir
+  cd $locDir
+  for map in \
+    Full_torus_r251_phi181_z251_18Apr2018.dat \
+    Symm_torus_r251_phi121_z251_2008.dat \
+    Symm_torus_r2501_phi16_z251_24Apr2018.dat \
+    Symm_solenoid_r601_phi1_z1201_2008.dat
+  do
+    # -N only redownloads if timestamp/filesize is newer/different
+    wget -N --no-check-certificate $webDir/$map
+  done
+  cd -
 fi
 
 rm -rf coatjava

--- a/etc/services/reconstruction.yaml
+++ b/etc/services/reconstruction.yaml
@@ -44,8 +44,8 @@ configuration:
       compression: 2
   services:
     DCHB:
-      torusMap: clas12-fieldmap-torus.dat
-      solenoidMap: clas12-fieldmap-solenoid.dat
+      torusMap: Symm_torus_r2501_phi16_z251_24Apr2018.dat
+      solenoidMap: Symm_solenoid_r601_phi1_z1201_2008.dat
 
 mime-types:
   - binary/data-hipo

--- a/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/trajectory/TrkSwimmer.java
+++ b/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/trajectory/TrkSwimmer.java
@@ -219,7 +219,7 @@ public class TrkSwimmer {
         String clasDictionaryPath = CLASResources.getResourcePath("etc");
 
         //OK, see if we can create a Solenoid
-        String solenoidFileName = clasDictionaryPath + "/data/magfield/clas12-fieldmap-solenoid.dat";
+        String solenoidFileName = clasDictionaryPath + "/data/magfield/Symm_solenoid_r601_phi1_z1201_2008.dat";
 
         File solenoidFile = new File(solenoidFileName);
         try {

--- a/reconstruction/eb/src/main/java/org/jlab/service/eb/EBEngine.java
+++ b/reconstruction/eb/src/main/java/org/jlab/service/eb/EBEngine.java
@@ -237,7 +237,7 @@ public class EBEngine extends ReconstructionEngine {
 
     public void dropBanks(DataEvent de) {
         if (this.alreadyDroppedBanks==false) {
-            System.out.println("\nEBEngine:  dropping REC banks!\n");
+            System.out.println("["+this.getName()+"]  dropping REC banks!\n");
             this.alreadyDroppedBanks=true;
         }
         de.removeBank(eventBank);
@@ -248,10 +248,17 @@ public class EBEngine extends ReconstructionEngine {
         de.removeBank(trackBank);
         de.removeBank(crossBank);
         de.removeBank(ftBank);
+        de.removeBank(trajectoryBank);
+        de.removeBank(covMatrixBank);
     }
 
     @Override
     public boolean init() {
+
+        if (this.getEngineConfigString("dropBanks")=="true") {
+            dropBanks=true;
+        }
+
         requireConstants(EBCCDBConstants.getAllTableNames());
         this.getConstantsManager().setVariation("default");
         System.out.println("["+this.getName()+"] --> event builder is ready....");

--- a/validation/advanced-tests/run-eb-tests.sh
+++ b/validation/advanced-tests/run-eb-tests.sh
@@ -100,14 +100,11 @@ then
         fi
     fi
 
-    # download test files
-    if ! [ -e ${webFileStub}.evio ]
-    then
-        rm -f ${webFileStub}.evio.gz
-        wget --no-check-certificate $webDir/${webFileStub}.evio.gz
-        if [ $? != 0 ] ; then echo "wget validation files failure" ; exit 1 ; fi
-        gunzip -f ${webFileStub}.evio.gz
-    fi
+    # download test files, if necessary:
+    rm -f ${webFileStub}.evio
+    wget -N --no-check-certificate $webDir/${webFileStub}.evio.gz
+    if [ $? != 0 ] ; then echo "wget validation files failure" ; exit 1 ; fi
+    gunzip -f ${webFileStub}.evio.gz
 
     rm -f ${webFileStub}.hipo
     rm -f out_${webFileStub}.hipo

--- a/validation/etc
+++ b/validation/etc
@@ -1,0 +1,1 @@
+../coatjava/etc

--- a/validation/unit-tests/run-unit-tests.sh
+++ b/validation/unit-tests/run-unit-tests.sh
@@ -1,13 +1,13 @@
-#!/bin/sh -f
+#!/bin/bash
 
 # coatjava must already be built at ../../coatjava/
 
 # set environment
 COAT="../../coatjava/"
-classPath="$COAT/lib/services/*:$COAT/lib/clas/*:$COAT/lib/utils/*:../lib/*:src/"
 
-export TORUSMAP=clas12-fieldmap-torus.dat
-export SOLENOIDMAP=clas12-fieldmap-solenoid.dat
+source $COAT/bin/env.sh
+
+classPath="$COAT/lib/services/*:$COAT/lib/clas/*:$COAT/lib/utils/*:../lib/*:src/"
 
 # compile codes
 javac -cp $classPath src/events/TestEvent.java


### PR DESCRIPTION
* All maps renamed with specific names and documented
* All maps now stored in the official public repository
* That repository is now at JLab instead of github (due to filesize limitations)
  * https://clasweb.jlab.org/clas12offline/magfield, see README
* Currently all maps are retrieved by the build script
  * but only if necessary,  i.e. newer timestamp or filesize different than existing local copy
* Default torus map in software is now the latest and greatest one
  * `Symm_torus_r2501_phi16_z251_24Apr2018.dat`
* Changing the choice of maps is now located in only 2 files:
  * `etc/services/reconstruction.yaml` for CLARA
  * `bin/env.sh` for standalone
* (plus minor, unrelated EB changes for dropping banks)
