### PR TITLE
cnuphys no longer ignores spotbugs-exclude.xml

### DIFF
--- a/common-tools/cnuphys/parent/pom.xml
+++ b/common-tools/cnuphys/parent/pom.xml
@@ -17,6 +17,14 @@
       </repository>
   </repositories>
 
+  <dependencies>
+    <dependency>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs</artifactId>
+      <version>3.1.0</version>
+    </dependency>
+  </dependencies>
+
   <build>
     <extensions>
       <extension>
@@ -25,6 +33,17 @@
         <version>2.8</version>
       </extension>
     </extensions>
+
+    <plugins>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <version>3.1.0-RC6</version>
+        <configuration>
+          <excludeFilterFile>spotbugs-exclude.xml</excludeFilterFile>
+        </configuration>
+      </plugin>
+    </plugins>
   </build>
   
   <distributionManagement>
@@ -34,6 +53,4 @@
     </repository>
   </distributionManagement>
 
-<!-- project Dependencies -->
-<!-- BUILD section for creating one JAR -->
 </project>


### PR DESCRIPTION
This speeds up the spotbugs check and produces fewer (non-serious) warnings/errors