### PR TITLE
CVT: refactor service and small fixes

### DIFF
--- a/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/banks/RecoBankWriter.java
+++ b/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/banks/RecoBankWriter.java
@@ -409,9 +409,9 @@ public class RecoBankWriter {
         DataBank bank = event.createBank("CVTRec::Cosmics", cosmics.size());
         // an array representing the ids of the crosses that belong to the track: for a helical track with the current
         // 4 regions of SVT + 1 region of BMT there can be up to 4*2 (*2: for each hemisphere) crosses of type SVT and 2*2 of type PSEUDOBMT (1 for the C detector and 1 for the Z detector)
-        List<Integer> crossIdxArray = new ArrayList<Integer>();
 
         for (int i = 0; i < cosmics.size(); i++) {
+            List<Integer> crossIdxArray = new ArrayList<Integer>();
 
 
             bank.setShort("ID", i, (short) cosmics.get(i).get_Id());

--- a/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/services/CVTRecHandler.java
+++ b/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/services/CVTRecHandler.java
@@ -1,0 +1,469 @@
+package org.jlab.rec.cvt.services;
+
+//import cnuphys.magfield.MagneticFields;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jlab.detector.calib.utils.DatabaseConstantProvider;
+import org.jlab.detector.geant4.v2.SVT.SVTConstants;
+import org.jlab.detector.geant4.v2.SVT.SVTStripFactory;
+import org.jlab.io.base.DataBank;
+import org.jlab.io.base.DataEvent;
+import org.jlab.io.hipo.HipoDataEvent;
+import org.jlab.io.hipo.HipoDataSource;
+import org.jlab.io.hipo.HipoDataSync;
+import org.jlab.rec.cvt.Constants;
+import org.jlab.rec.cvt.banks.HitReader;
+import org.jlab.rec.cvt.banks.RecoBankWriter;
+import org.jlab.rec.cvt.bmt.CCDBConstantsLoader;
+import org.jlab.rec.cvt.cluster.Cluster;
+import org.jlab.rec.cvt.cluster.ClusterFinder;
+import org.jlab.rec.cvt.cross.Cross;
+import org.jlab.rec.cvt.cross.CrossList;
+import org.jlab.rec.cvt.cross.CrossMaker;
+import org.jlab.rec.cvt.cross.HelixCrossListFinder;
+import org.jlab.rec.cvt.cross.StraightTrackCrossListFinder;
+import org.jlab.rec.cvt.hit.ADCConvertor;
+import org.jlab.rec.cvt.hit.FittedHit;
+import org.jlab.rec.cvt.hit.Hit;
+import org.jlab.rec.cvt.track.Seed;
+import org.jlab.rec.cvt.track.StraightTrack;
+import org.jlab.rec.cvt.track.Track;
+import org.jlab.rec.cvt.track.TrackCandListFinder;
+import org.jlab.rec.cvt.track.TrackListFinder;
+import org.jlab.rec.cvt.track.TrackSeederCA;
+import org.jlab.rec.cvt.track.fit.KFitter;
+import org.jlab.rec.cvt.trajectory.TrajectoryFinder;
+import org.jlab.rec.cvt.trajectory.TrkSwimmer;
+
+/**
+ *
+ */
+
+public class CVTRecHandler {
+
+    RecoBankWriter rbc = new RecoBankWriter();
+    org.jlab.rec.cvt.svt.Geometry SVTGeom;
+    org.jlab.rec.cvt.bmt.Geometry BMTGeom;
+    SVTStripFactory svtIdealStripFactory;
+    
+    public CVTRecHandler() {
+        org.jlab.rec.cvt.svt.Constants.Load();
+        SVTGeom = new org.jlab.rec.cvt.svt.Geometry();
+        BMTGeom = new org.jlab.rec.cvt.bmt.Geometry();
+    }
+
+    public CVTRecHandler(org.jlab.rec.cvt.svt.Geometry svtg, org.jlab.rec.cvt.bmt.Geometry bmtg) {
+        SVTGeom = svtg;
+        BMTGeom = bmtg;
+    }
+    
+    String FieldsConfig = "";
+    int Run = -1;
+  
+    public void setRunConditionsParameters(DataEvent event, String Fields, int iRun, boolean addMisAlignmts, String misAlgnFile) {
+        if (event.hasBank("RUN::config") == false) {
+            System.err.println("RUN CONDITIONS NOT READ!");
+            return;
+        }
+
+        int Run = iRun;
+
+        boolean isCosmics = false;
+        DataBank bank = event.getBank("RUN::config");
+        //System.out.println(bank.getInt("Event")[0]);
+        if (bank.getByte("type", 0) == 0) {
+        }
+        if (bank.getByte("mode", 0) == 1) {
+            isCosmics = true;
+        }
+
+        boolean isSVTonly = false;
+
+        // Load the fields
+        //-----------------
+        String newConfig = "SOLENOID" + bank.getFloat("solenoid", 0);
+
+        if (Fields.equals(newConfig) == false) {
+            // Load the Constants
+            
+            System.out.println("  CHECK CONFIGS..............................." + FieldsConfig + " = ? " + newConfig);
+            Constants.Load(isCosmics, isSVTonly, (double) bank.getFloat("solenoid", 0));
+            // Load the Fields
+            System.out.println("************************************************************SETTING FIELD SCALE *****************************************************");
+            TrkSwimmer.setMagneticFieldScale(bank.getFloat("solenoid", 0)); // something changed in the configuration
+            //double shift =0;
+            //if(bank.getInt("run", 0)>1840)
+            //    shift = -1.9;
+            //MagneticFields.getInstance().setSolenoidShift(shift);
+//            this.setFieldsConfig(newConfig);
+            
+            CCDBConstantsLoader.Load(new DatabaseConstantProvider(bank.getInt("run", 0), "default"));
+        }
+        this.setFieldsConfig(newConfig);
+
+        // Load the constants
+        //-------------------
+        int newRun = bank.getInt("run", 0);
+
+        if (Run != newRun) {
+            this.setRun(newRun);
+        }
+      
+        Run = newRun;
+        this.setRun(Run);
+    }
+
+    public int getRun() {
+        return Run;
+    }
+
+    public void setRun(int run) {
+        Run = run;
+    }
+
+    public String getFieldsConfig() {
+        return FieldsConfig;
+    }
+
+    public void setFieldsConfig(String fieldsConfig) {
+        FieldsConfig = fieldsConfig;
+    }
+    
+    List<FittedHit> SVThits   = null;
+    List<FittedHit> BMThits   = null;
+    List<Cluster> clusters    = null;
+    List<Cluster> SVTclusters = null;
+    List<Cluster> BMTclusters = null;
+    public org.jlab.rec.cvt.bmt.Geometry getBMTGeom() {
+		return BMTGeom;
+	}
+
+	public void setBMTGeom(org.jlab.rec.cvt.bmt.Geometry bMTGeom) {
+		BMTGeom = bMTGeom;
+	}
+
+	public org.jlab.rec.cvt.svt.Geometry getSVTGeom() {
+		return SVTGeom;
+	}
+
+	public void setSVTGeom(org.jlab.rec.cvt.svt.Geometry sVTGeom) {
+		SVTGeom = sVTGeom;
+	}
+
+	public List<FittedHit> getSVThits() {
+		return SVThits;
+	}
+
+	public void setSVThits(List<FittedHit> sVThits) {
+		SVThits = sVThits;
+	}
+
+	public List<FittedHit> getBMThits() {
+		return BMThits;
+	}
+
+	public void setBMThits(List<FittedHit> bMThits) {
+		BMThits = bMThits;
+	}
+
+	public List<Cluster> getSVTclusters() {
+		return SVTclusters;
+	}
+
+	public void setSVTclusters(List<Cluster> sVTclusters) {
+		SVTclusters = sVTclusters;
+	}
+
+	public List<Cluster> getBMTclusters() {
+		return BMTclusters;
+	}
+
+	public void setBMTclusters(List<Cluster> bMTclusters) {
+		BMTclusters = bMTclusters;
+	}
+
+    public boolean loadClusters(DataEvent event) {
+        SVThits = new ArrayList<FittedHit>();
+        BMThits = new ArrayList<FittedHit>();
+        clusters = new ArrayList<Cluster>();
+        SVTclusters = new ArrayList<Cluster>();
+        BMTclusters = new ArrayList<Cluster>();
+    	ADCConvertor adcConv = new ADCConvertor();
+        HitReader hitRead = new HitReader();
+        hitRead.fetch_SVTHits(event, adcConv, -1, -1, SVTGeom);
+        hitRead.fetch_BMTHits(event, adcConv, BMTGeom);
+
+        List<Hit> hits = new ArrayList<Hit>();
+        //I) get the hits
+        List<Hit> svt_hits = hitRead.get_SVTHits();
+        if (svt_hits != null && svt_hits.size() > 0) {
+            hits.addAll(svt_hits);
+        }
+
+        List<Hit> bmt_hits = hitRead.get_BMTHits();
+        if (bmt_hits != null && bmt_hits.size() > 0) {
+            hits.addAll(bmt_hits);
+        }
+
+        //II) process the hits		
+        //1) exit if hit list is empty
+        if (hits.size() == 0) {
+            return false;
+        }
+        
+        //2) find the clusters from these hits
+        ClusterFinder clusFinder = new ClusterFinder();
+        clusters.addAll(clusFinder.findClusters(svt_hits, BMTGeom));
+        
+        clusters.addAll(clusFinder.findClusters(bmt_hits, BMTGeom)); 
+        
+        if (clusters.size() == 0) {
+            return false;
+        }
+        
+        // fill the fitted hits list.
+        if (clusters.size() != 0) {
+            for (int i = 0; i < clusters.size(); i++) {
+                if (clusters.get(i).get_Detector() == 0) {
+                    SVTclusters.add(clusters.get(i));
+                    SVThits.addAll(clusters.get(i));
+                }
+                if (clusters.get(i).get_Detector() == 1) {
+                    BMTclusters.add(clusters.get(i));
+                    BMThits.addAll(clusters.get(i));
+                }
+            }
+        }
+        
+    	return true;
+    }
+    
+    List<ArrayList<Cross>> crosses = null;
+    public void loadCrosses() {
+    	 crosses = new ArrayList<ArrayList<Cross>>();
+         CrossMaker crossMake = new CrossMaker();
+         crosses = crossMake.findCrosses(clusters, SVTGeom);
+    }
+    
+    public List<ArrayList<Cross>> getCrosses() {
+		return crosses;
+	}
+
+	public void setCrosses(List<ArrayList<Cross>> crosses) {
+		this.crosses = crosses;
+	}
+
+	List<Track> trks = null;
+	public List<Track> getTrks() {
+		return trks;
+	}
+	public void setTrks(List<Track> trks) {
+		this.trks = trks;
+	}
+
+	
+	public List<StraightTrack> cosmicsTracking(){
+		if( this.crosses == null ) return null;
+		
+        StraightTrackCrossListFinder crossLister = new StraightTrackCrossListFinder();
+        CrossList crosslist = crossLister.findCosmicsCandidateCrossLists(crosses, SVTGeom,
+                BMTGeom, 3);
+        if (crosslist == null || crosslist.size() == 0) {
+            return null;
+        }
+        
+        List<StraightTrack> cosmics = new ArrayList<StraightTrack>();
+
+        TrackCandListFinder trkcandFinder = new TrackCandListFinder();
+        cosmics = trkcandFinder.getStraightTracks(crosslist, crosses.get(1), SVTGeom, BMTGeom);
+        
+        //------------------------
+        if (cosmics.size() == 0) {
+            this.CleanupSpuriousCrosses(crosses, null) ;
+            return null;
+        }
+
+        for (int k1 = 0; k1 < cosmics.size(); k1++) {
+        	cosmics.get(k1).set_Id(k1 + 1);
+        	for (int k2 = 0; k2 < cosmics.get(k1).size(); k2++) {
+        		cosmics.get(k1).get(k2).set_AssociatedTrackID(cosmics.get(k1).get_Id()); // associate crosses
+        		if (cosmics.get(k1).get(k2).get_Cluster1() != null) {
+        			cosmics.get(k1).get(k2).get_Cluster1().set_AssociatedTrackID(cosmics.get(k1).get_Id()); // associate cluster1 in cross
+        		}
+        		if (cosmics.get(k1).get(k2).get_Cluster2() != null) {
+        			cosmics.get(k1).get(k2).get_Cluster2().set_AssociatedTrackID(cosmics.get(k1).get_Id()); // associate cluster2 in cross	
+        		}
+        		if (cosmics.get(k1).get(k2).get_Cluster1() != null) {
+        			for (int k3 = 0; k3 < cosmics.get(k1).get(k2).get_Cluster1().size(); k3++) { //associate hits
+        				cosmics.get(k1).get(k2).get_Cluster1().get(k3).set_AssociatedTrackID(cosmics.get(k1).get_Id());
+        			}
+        		}
+        		if (cosmics.get(k1).get(k2).get_Cluster2() != null) {
+        			for (int k4 = 0; k4 < cosmics.get(k1).get(k2).get_Cluster2().size(); k4++) { //associate hits
+        				cosmics.get(k1).get(k2).get_Cluster2().get(k4).set_AssociatedTrackID(cosmics.get(k1).get_Id());
+        			}
+        		}
+        	}
+        	trkcandFinder.matchClusters(SVTclusters, new TrajectoryFinder(), SVTGeom, BMTGeom, true,
+        			cosmics.get(k1).get_Trajectory(), k1 + 1);
+        }
+        this.CleanupSpuriousCrosses(crosses, null) ;
+        //4)  ---  write out the banks			
+
+        return cosmics;
+	}
+	
+	public List<Track> beamTracking(){
+		if( this.crosses == null ) return null;
+		TrackSeederCA trseed = new TrackSeederCA();
+        
+        KFitter kf;
+        List<Track> trkcands = new ArrayList<Track>();
+        
+        //List<Seed> seeds = trseed.findSeed(SVTclusters, SVTGeom, crosses.get(1), BMTGeom);
+        List<Seed> seeds = trseed.findSeed(crosses.get(0), crosses.get(1), SVTGeom, BMTGeom);
+        
+        for (Seed seed : seeds) { 
+            
+            kf = new KFitter(seed, SVTGeom );
+            kf.runFitter(SVTGeom, BMTGeom);
+            //System.out.println(" OUTPUT SEED......................");
+            trkcands.add(kf.OutputTrack(seed, SVTGeom));
+            if (kf.setFitFailed == false) {
+                trkcands.get(trkcands.size() - 1).set_TrackingStatus(2);
+           } else {
+                trkcands.get(trkcands.size() - 1).set_TrackingStatus(1);
+           }
+        }
+
+        if (trkcands.size() == 0) {
+            this.CleanupSpuriousCrosses(crosses, null) ;
+            return null;
+        }
+
+        //This last part does ELoss C
+        TrackListFinder trkFinder = new TrackListFinder();
+        trks = new ArrayList<Track>();
+        trks = trkFinder.getTracks(trkcands, SVTGeom, BMTGeom);
+//        System.out.println( " *** *** trkcands " + trkcands.size() + " * trks " + trks.size());
+//        trkFinder.removeOverlappingTracks(trks); //turn off until debugged
+        
+        for (int c = 0; c < trks.size(); c++) {
+            trks.get(c).set_Id(c + 1);
+            for (int ci = 0; ci < trks.get(c).size(); ci++) {
+
+                if (crosses.get(0) != null && crosses.get(0).size() > 0) {
+//                    for (Cross crsSVT : crosses.get(0)) {
+                	for (int jj=0 ; jj < crosses.get(0).size(); jj++) {
+                		Cross crsSVT = crosses.get(0).get(jj);
+                        if (crsSVT.get_Sector() == trks.get(c).get(ci).get_Sector() && crsSVT.get_Cluster1()!=null && crsSVT.get_Cluster2()!=null 
+                                && trks.get(c).get(ci).get_Cluster1()!=null && trks.get(c).get(ci).get_Cluster2()!=null
+                                && crsSVT.get_Cluster1().get_Id() == trks.get(c).get(ci).get_Cluster1().get_Id()
+                                && crsSVT.get_Cluster2().get_Id() == trks.get(c).get(ci).get_Cluster2().get_Id()) {  
+                            crsSVT.set_Point(trks.get(c).get(ci).get_Point());
+                            trks.get(c).get(ci).set_Id(crsSVT.get_Id());
+                            crsSVT.set_PointErr(trks.get(c).get(ci).get_PointErr());
+                            crsSVT.set_Dir(trks.get(c).get(ci).get_Dir());
+                            crsSVT.set_DirErr(trks.get(c).get(ci).get_DirErr());
+                            crsSVT.set_AssociatedTrackID(c + 1);
+                            crsSVT.get_Cluster1().set_AssociatedTrackID(c + 1);
+                            for (FittedHit h : crsSVT.get_Cluster1()) {
+                                h.set_AssociatedTrackID(c + 1);
+                            }
+                            for (FittedHit h : crsSVT.get_Cluster2()) {
+                                h.set_AssociatedTrackID(c + 1);
+                            }
+                            crsSVT.get_Cluster2().set_AssociatedTrackID(c + 1);
+
+                        }
+                    }
+                }
+                if (crosses.get(1) != null && crosses.get(1).size() > 0) {
+//                    for (Cross crsBMT : crosses.get(1)) {
+                	for (int jj=0 ; jj < crosses.get(1).size(); jj++) {
+                		Cross crsBMT = crosses.get(1).get(jj);
+                        if (crsBMT.get_Id() == trks.get(c).get(ci).get_Id()) {
+                            crsBMT.set_Point(trks.get(c).get(ci).get_Point());
+                            crsBMT.set_PointErr(trks.get(c).get(ci).get_PointErr());
+                            crsBMT.set_Dir(trks.get(c).get(ci).get_Dir());
+                            crsBMT.set_DirErr(trks.get(c).get(ci).get_DirErr());
+                            crsBMT.set_AssociatedTrackID(c + 1);
+                            crsBMT.get_Cluster1().set_AssociatedTrackID(c + 1);
+                            for (FittedHit h : crsBMT.get_Cluster1()) {
+                                h.set_AssociatedTrackID(c + 1);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        
+        //------------------------
+        // set index associations
+        if (trks.size() > 0) {
+            this.CleanupSpuriousCrosses(crosses, trks) ;
+        }
+        return trks;
+    }
+
+
+    private void CleanupSpuriousCrosses(List<ArrayList<Cross>> crosses, List<Track> trks) {
+        List<Cross> rmCrosses = new ArrayList<Cross>();
+        
+        if( crosses.get(0) != null ) {
+	        for(Cross c : crosses.get(0)) {
+	            double z = SVTGeom.transformToFrame(c.get_Sector(), c.get_Region()*2, c.get_Point().x(), c.get_Point().y(),c.get_Point().z(), "local", "").z();
+	            if(z<-0.1 || z>SVTConstants.MODULELEN) {
+	                rmCrosses.add(c);
+	            }
+	        }
+        
+        
+	        for(int j = 0; j<crosses.get(0).size(); j++) {
+	            for(Cross c : rmCrosses) {
+	                if(crosses.get(0).get(j).get_Id()==c.get_Id())
+	                    crosses.get(0).remove(j);
+	            }
+	        } 
+        }
+       
+        if(trks!=null && rmCrosses!=null) {
+            List<Track> rmTrks = new ArrayList<Track>();
+            for(Track t:trks) {
+                boolean rmFlag=false;
+                for(Cross c: rmCrosses) {
+                    if(c!=null && t!=null && c.get_AssociatedTrackID()==t.get_Id())
+                        rmFlag=true;
+                }
+                if(rmFlag==true)
+                    rmTrks.add(t);
+            }
+            trks.removeAll(rmTrks);
+        }
+    }
+
+    public boolean init() {
+        System.out.println(" ........................................ trying to connect to db ");
+//        CCDBConstantsLoader.Load(new DatabaseConstantProvider( "sqlite:///clas12.sqlite", "default"));
+        CCDBConstantsLoader.Load(new DatabaseConstantProvider(10, "default"));
+               
+        DatabaseConstantProvider cp = new DatabaseConstantProvider(11, "default");
+//        DatabaseConstantProvider cp = new DatabaseConstantProvider( "sqlite:///clas12.sqlite", "default");
+        cp = SVTConstants.connect( cp );
+        SVTConstants.loadAlignmentShifts( cp );
+        cp.disconnect();    
+        this.setSVTDB(cp);
+        
+        TrkSwimmer.getMagneticFields();
+        return true;
+    }
+    private DatabaseConstantProvider _SVTDB;
+    private synchronized void setSVTDB(DatabaseConstantProvider SVTDB) {
+        _SVTDB = SVTDB;
+    }
+    private synchronized DatabaseConstantProvider getSVTDB() {
+        return _SVTDB;
+    }
+
+}

--- a/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/services/CVTReconstruction.java
+++ b/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/services/CVTReconstruction.java
@@ -16,28 +16,10 @@ import org.jlab.io.hipo.HipoDataEvent;
 import org.jlab.io.hipo.HipoDataSource;
 import org.jlab.io.hipo.HipoDataSync;
 import org.jlab.rec.cvt.Constants;
-import org.jlab.rec.cvt.banks.HitReader;
 import org.jlab.rec.cvt.banks.RecoBankWriter;
 import org.jlab.rec.cvt.bmt.CCDBConstantsLoader;
-import org.jlab.rec.cvt.cluster.Cluster;
-import org.jlab.rec.cvt.cluster.ClusterFinder;
-import org.jlab.rec.cvt.cross.Cross;
-import org.jlab.rec.cvt.cross.CrossList;
-import org.jlab.rec.cvt.cross.CrossMaker;
-import org.jlab.rec.cvt.cross.HelixCrossListFinder;
-import org.jlab.rec.cvt.cross.StraightTrackCrossListFinder;
-import org.jlab.rec.cvt.hit.ADCConvertor;
-import org.jlab.rec.cvt.hit.FittedHit;
-import org.jlab.rec.cvt.hit.Hit;
-import org.jlab.rec.cvt.track.Seed;
 import org.jlab.rec.cvt.track.StraightTrack;
 import org.jlab.rec.cvt.track.Track;
-import org.jlab.rec.cvt.track.TrackCandListFinder;
-import org.jlab.rec.cvt.track.TrackListFinder;
-import org.jlab.rec.cvt.track.TrackSeeder;
-import org.jlab.rec.cvt.track.TrackSeederCA;
-import org.jlab.rec.cvt.track.fit.KFitter;
-import org.jlab.rec.cvt.trajectory.TrajectoryFinder;
 import org.jlab.rec.cvt.trajectory.TrkSwimmer;
 //import org.jlab.service.eb.EBHBEngine;
 //import org.jlab.service.eb.EBTBEngine;
@@ -66,7 +48,7 @@ public class CVTReconstruction extends ReconstructionEngine {
     String FieldsConfig = "";
     int Run = -1;
   
-    public void setRunConditionsParameters(DataEvent event, String FieldsConfig, int iRun, boolean addMisAlignmts, String misAlgnFile) {
+    public void setRunConditionsParameters(DataEvent event, String Fields, int iRun, boolean addMisAlignmts, String misAlgnFile) {
         if (event.hasBank("RUN::config") == false) {
             System.err.println("RUN CONDITIONS NOT READ!");
             return;
@@ -91,7 +73,7 @@ public class CVTReconstruction extends ReconstructionEngine {
         //-----------------
         String newConfig = "SOLENOID" + bank.getFloat("solenoid", 0);
 
-        if (FieldsConfig.equals(newConfig) == false) {
+        if (Fields.equals(newConfig) == false) {
             // Load the Constants
             
             System.out.println("  CHECK CONFIGS..............................." + FieldsConfig + " = ? " + newConfig);
@@ -103,30 +85,18 @@ public class CVTReconstruction extends ReconstructionEngine {
             //if(bank.getInt("run", 0)>1840)
             //    shift = -1.9;
             //MagneticFields.getInstance().setSolenoidShift(shift);
-            this.setFieldsConfig(newConfig);
+//            this.setFieldsConfig(newConfig);
             
             CCDBConstantsLoader.Load(new DatabaseConstantProvider(bank.getInt("run", 0), "default"));
         }
-        FieldsConfig = newConfig;
+        this.setFieldsConfig(newConfig);
 
         // Load the constants
         //-------------------
         int newRun = bank.getInt("run", 0);
 
         if (Run != newRun) {
-            boolean align=false;
-  //        if(newRun>99)
-  //              align = true;
-   //             DatabaseConstantProvider cp = new DatabaseConstantProvider(newRun, "default");
-   //             cp = SVTConstants.connect( cp );
-   //             SVTConstants.loadAlignmentShifts( cp );
-   //             cp.disconnect();    
-    //            this.setSVTDB(cp);
-   //             SVTStripFactory svtStripFactory = new SVTStripFactory( this.getSVTDB(), align );
-    //            SVTGeom.setSvtStripFactory(svtStripFactory);
-
             this.setRun(newRun);
-
         }
       
         Run = newRun;
@@ -148,266 +118,44 @@ public class CVTReconstruction extends ReconstructionEngine {
     public void setFieldsConfig(String fieldsConfig) {
         FieldsConfig = fieldsConfig;
     }
-    @Override
+    
+	@Override
  public boolean processDataEvent(DataEvent event) {
-        this.setRunConditionsParameters(event, FieldsConfig, Run, false, "");
+		
+		CVTRecHandler recHandler = new CVTRecHandler(SVTGeom,BMTGeom);
+		setRunConditionsParameters(event, this.getFieldsConfig(), this.getRun(), false, "");
 
-        this.FieldsConfig = this.getFieldsConfig();
-        this.Run = this.getRun();
-
-        ADCConvertor adcConv = new ADCConvertor();
-
+        
+        
         RecoBankWriter rbc = new RecoBankWriter();
 
-        HitReader hitRead = new HitReader();
-        hitRead.fetch_SVTHits(event, adcConv, -1, -1, SVTGeom);
-        hitRead.fetch_BMTHits(event, adcConv, BMTGeom);
-
-        List<Hit> hits = new ArrayList<Hit>();
-        //I) get the hits
-        List<Hit> svt_hits = hitRead.get_SVTHits();
-        if (svt_hits != null && svt_hits.size() > 0) {
-            hits.addAll(svt_hits);
-        }
-
-        List<Hit> bmt_hits = hitRead.get_BMTHits();
-        if (bmt_hits != null && bmt_hits.size() > 0) {
-            hits.addAll(bmt_hits);
-        }
-
-        //II) process the hits		
-        List<FittedHit> SVThits = new ArrayList<FittedHit>();
-        List<FittedHit> BMThits = new ArrayList<FittedHit>();
-        //1) exit if hit list is empty
-        if (hits.size() == 0) {
-            return true;
-        }
+        if( recHandler.loadClusters( event ) == false ) { return true; };
        
-        List<Cluster> clusters = new ArrayList<Cluster>();
-        List<Cluster> SVTclusters = new ArrayList<Cluster>();
-        List<Cluster> BMTclusters = new ArrayList<Cluster>();
+        recHandler.loadCrosses();
 
-        //2) find the clusters from these hits
-        ClusterFinder clusFinder = new ClusterFinder();
-        clusters.addAll(clusFinder.findClusters(svt_hits, BMTGeom));
-        
-        clusters.addAll(clusFinder.findClusters(bmt_hits, BMTGeom)); 
-        
-        if (clusters.size() == 0) {
-            return true;
-        }
-        
-        // fill the fitted hits list.
-        if (clusters.size() != 0) {
-            for (int i = 0; i < clusters.size(); i++) {
-                if (clusters.get(i).get_Detector() == 0) {
-                    SVTclusters.add(clusters.get(i));
-                    SVThits.addAll(clusters.get(i));
-                }
-                if (clusters.get(i).get_Detector() == 1) {
-                    BMTclusters.add(clusters.get(i));
-                    BMThits.addAll(clusters.get(i));
-                }
-            }
-        }
-
-        List<ArrayList<Cross>> crosses = new ArrayList<ArrayList<Cross>>();
-        CrossMaker crossMake = new CrossMaker();
-        crosses = crossMake.findCrosses(clusters, SVTGeom);
-        
+        //System.out.println(" Number of crosses "+crosses.get(0).size()+" + "+crosses.get(1).size());
         if(Constants.isCosmicsData()==true) { 
-            //4) make list of crosses consistent with a track candidate
-            StraightTrackCrossListFinder crossLister = new StraightTrackCrossListFinder();
-            CrossList crosslist = crossLister.findCosmicsCandidateCrossLists(crosses, SVTGeom,
-                    BMTGeom, 3);
-            if (crosslist == null || crosslist.size() == 0) {
-                // create the clusters and fitted hits banks
-                rbc.appendCVTCosmicsBanks(event, SVThits, BMThits, SVTclusters, BMTclusters, crosses, null);
-
-                return true;
-            }
-            
-            List<StraightTrack> cosmics = new ArrayList<StraightTrack>();
-
-            TrackCandListFinder trkcandFinder = new TrackCandListFinder();
-            cosmics = trkcandFinder.getStraightTracks(crosslist, crosses.get(1), SVTGeom, BMTGeom);
-            
-            //REMOVE THIS
-            //crosses.get(0).addAll(crosses.get(1));
-            //------------------------
-            if (cosmics.size() == 0) {
-                this.CleanupSpuriousCrosses(crosses, null) ;
-                rbc.appendCVTCosmicsBanks(event, SVThits, BMThits, SVTclusters, BMTclusters, crosses, null);
-
-                return true;
-            }
-
-            if (cosmics.size() > 0) {
-                for (int k1 = 0; k1 < cosmics.size(); k1++) {
-                    cosmics.get(k1).set_Id(k1 + 1);
-                    for (int k2 = 0; k2 < cosmics.get(k1).size(); k2++) {
-                        cosmics.get(k1).get(k2).set_AssociatedTrackID(cosmics.get(k1).get_Id()); // associate crosses
-                        if (cosmics.get(k1).get(k2).get_Cluster1() != null) {
-                            cosmics.get(k1).get(k2).get_Cluster1().set_AssociatedTrackID(cosmics.get(k1).get_Id()); // associate cluster1 in cross
-                        }
-                        if (cosmics.get(k1).get(k2).get_Cluster2() != null) {
-                            cosmics.get(k1).get(k2).get_Cluster2().set_AssociatedTrackID(cosmics.get(k1).get_Id()); // associate cluster2 in cross	
-                        }
-                        if (cosmics.get(k1).get(k2).get_Cluster1() != null) {
-                            for (int k3 = 0; k3 < cosmics.get(k1).get(k2).get_Cluster1().size(); k3++) { //associate hits
-                                cosmics.get(k1).get(k2).get_Cluster1().get(k3).set_AssociatedTrackID(cosmics.get(k1).get_Id());
-                            }
-                        }
-                        if (cosmics.get(k1).get(k2).get_Cluster2() != null) {
-                            for (int k4 = 0; k4 < cosmics.get(k1).get(k2).get_Cluster2().size(); k4++) { //associate hits
-                                cosmics.get(k1).get(k2).get_Cluster2().get(k4).set_AssociatedTrackID(cosmics.get(k1).get_Id());
-                            }
-                        }
-                    }
-                    trkcandFinder.matchClusters(SVTclusters, new TrajectoryFinder(), SVTGeom, BMTGeom, true,
-                            cosmics.get(k1).get_Trajectory(), k1 + 1);
-                }
-                this.CleanupSpuriousCrosses(crosses, null) ;
-                //4)  ---  write out the banks			
-                rbc.appendCVTCosmicsBanks(event, SVThits, BMThits, SVTclusters, BMTclusters, crosses, cosmics);
-            }
-        } else {//System.out.println(" FITTING SEED......................");
-//            TrackSeeder trseed = new TrackSeeder();
-            TrackSeederCA trseed = new TrackSeederCA();  // cellular automaton seeder
-           
-            KFitter kf;
-            List<Track> trkcands = new ArrayList<Track>();
-            HelixCrossListFinder hf = new HelixCrossListFinder();
-            
-            //List<Seed> seeds = trseed.findSeed(SVTclusters, SVTGeom, crosses.get(1), BMTGeom);
-            List<Seed> seeds = trseed.findSeed(crosses.get(0), crosses.get(1), SVTGeom, BMTGeom);
-            
-            for (Seed seed : seeds) { 
-                
-                kf = new KFitter(seed, SVTGeom, event);
-                kf.runFitter(SVTGeom, BMTGeom);
-                //System.out.println(" OUTPUT SEED......................");
-                trkcands.add(kf.OutputTrack(seed, SVTGeom));
-                if (kf.setFitFailed == false) {
-                    trkcands.get(trkcands.size() - 1).set_TrackingStatus(2);
-               } else {
-                    trkcands.get(trkcands.size() - 1).set_TrackingStatus(1);
-               }
-            }
-
-            if (trkcands.size() == 0) {
-                this.CleanupSpuriousCrosses(crosses, null) ;
-                rbc.appendCVTBanks(event, SVThits, BMThits, SVTclusters, BMTclusters, crosses, null);
-                return true;
-            }
-
-            //This last part does ELoss C
-            TrackListFinder trkFinder = new TrackListFinder();
-            List<Track> trks = new ArrayList<Track>();
-            trks = trkFinder.getTracks(trkcands, SVTGeom, BMTGeom);
-            //trkFinder.removeOverlappingTracks(trks); //turn off until debugged
-            
-            for (int c = 0; c < trks.size(); c++) {
-                trks.get(c).set_Id(c + 1);
-                for (int ci = 0; ci < trks.get(c).size(); ci++) {
-
-                    if (crosses.get(0).size() > 0) {
-                        for (Cross crsSVT : crosses.get(0)) {
-                            if (crsSVT.get_Sector() == trks.get(c).get(ci).get_Sector() && crsSVT.get_Cluster1()!=null && crsSVT.get_Cluster2()!=null 
-                                    && trks.get(c).get(ci).get_Cluster1()!=null && trks.get(c).get(ci).get_Cluster2()!=null
-                                    && crsSVT.get_Cluster1().get_Id() == trks.get(c).get(ci).get_Cluster1().get_Id()
-                                    && crsSVT.get_Cluster2().get_Id() == trks.get(c).get(ci).get_Cluster2().get_Id()) {  
-                                crsSVT.set_Point(trks.get(c).get(ci).get_Point());
-                                trks.get(c).get(ci).set_Id(crsSVT.get_Id());
-                                crsSVT.set_PointErr(trks.get(c).get(ci).get_PointErr());
-                                crsSVT.set_Dir(trks.get(c).get(ci).get_Dir());
-                                crsSVT.set_DirErr(trks.get(c).get(ci).get_DirErr());
-                                crsSVT.set_AssociatedTrackID(c + 1);
-                                crsSVT.get_Cluster1().set_AssociatedTrackID(c + 1);
-                                for (FittedHit h : crsSVT.get_Cluster1()) {
-                                    h.set_AssociatedTrackID(c + 1);
-                                }
-                                for (FittedHit h : crsSVT.get_Cluster2()) {
-                                    h.set_AssociatedTrackID(c + 1);
-                                }
-                                crsSVT.get_Cluster2().set_AssociatedTrackID(c + 1);
-
-                            }
-                        }
-                    }
-                    if (crosses.get(1).size() > 0) {
-                        for (Cross crsBMT : crosses.get(1)) {
-                            if (crsBMT.get_Id() == trks.get(c).get(ci).get_Id()) {
-                                crsBMT.set_Point(trks.get(c).get(ci).get_Point());
-                                crsBMT.set_PointErr(trks.get(c).get(ci).get_PointErr());
-                                crsBMT.set_Dir(trks.get(c).get(ci).get_Dir());
-                                crsBMT.set_DirErr(trks.get(c).get(ci).get_DirErr());
-                                crsBMT.set_AssociatedTrackID(c + 1);
-                                crsBMT.get_Cluster1().set_AssociatedTrackID(c + 1);
-                                for (FittedHit h : crsBMT.get_Cluster1()) {
-                                    h.set_AssociatedTrackID(c + 1);
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            
-            //crosses.get(0).removeAll(crosses.get(0));
-            //crosses.get(0).addAll(crossesOntrk);
-            //REMOVE THIS
-            //crosses.get(0).addAll(crosses.get(1));
-            //------------------------
-            // set index associations
-            if (trks.size() > 0) {
-                this.CleanupSpuriousCrosses(crosses, trks) ;
-                rbc.appendCVTBanks(event, SVThits, BMThits, SVTclusters, BMTclusters, crosses, trks);
-            }
-            //System.out.println("H");
+            List<StraightTrack> cosmics = recHandler.cosmicsTracking();   
+        	rbc.appendCVTCosmicsBanks(event, recHandler.getSVThits(), recHandler.getBMThits(), 
+        									 recHandler.getSVTclusters(), recHandler.getBMTclusters(), 
+        									 recHandler.getCrosses(), cosmics);
         } 
-        //event.show();
+        else {
+            List<Track> trks = recHandler.beamTracking();   
+        	rbc.appendCVTBanks(event, recHandler.getSVThits(), recHandler.getBMThits(), 
+        									 recHandler.getSVTclusters(), recHandler.getBMTclusters(), 
+        									 recHandler.getCrosses(), trks);
+        }
         return true;
-
     }
-    private void CleanupSpuriousCrosses(List<ArrayList<Cross>> crosses, List<Track> trks) {
-        List<Cross> rmCrosses = new ArrayList<Cross>();
-        
-        for(Cross c : crosses.get(0)) {
-            double z = SVTGeom.transformToFrame(c.get_Sector(), c.get_Region()*2, c.get_Point().x(), c.get_Point().y(),c.get_Point().z(), "local", "").z();
-            if(z<-0.1 || z>SVTConstants.MODULELEN) {
-                rmCrosses.add(c);
-            }
-        }
-       
-        
-        for(int j = 0; j<crosses.get(0).size(); j++) {
-            for(Cross c : rmCrosses) {
-                if(crosses.get(0).get(j).get_Id()==c.get_Id())
-                    crosses.get(0).remove(j);
-            }
-        } 
-        
-       
-        if(trks!=null && rmCrosses!=null) {
-            List<Track> rmTrks = new ArrayList<Track>();
-            for(Track t:trks) {
-                boolean rmFlag=false;
-                for(Cross c: rmCrosses) {
-                    if(c!=null && t!=null && c.get_AssociatedTrackID()==t.get_Id())
-                        rmFlag=true;
-                }
-                if(rmFlag==true)
-                    rmTrks.add(t);
-            }
-            trks.removeAll(rmTrks);
-        }
-    }
-
+    
     public boolean init() {
         System.out.println(" ........................................ trying to connect to db ");
+//        CCDBConstantsLoader.Load(new DatabaseConstantProvider( "sqlite:///clas12.sqlite", "default"));
         CCDBConstantsLoader.Load(new DatabaseConstantProvider(10, "default"));
-        
+               
         DatabaseConstantProvider cp = new DatabaseConstantProvider(11, "default");
+//        DatabaseConstantProvider cp = new DatabaseConstantProvider( "sqlite:///clas12.sqlite", "default");
         cp = SVTConstants.connect( cp );
         SVTConstants.loadAlignmentShifts( cp );
         cp.disconnect();    
@@ -427,8 +175,8 @@ public class CVTReconstruction extends ReconstructionEngine {
 
     
     public static void main(String[] args)  {
-    
-       String inputFile = "/Users/ziegler/Desktop/Work/Files/Data/DecodedData/CVT/svt123_003582.evio.0.hipo";
+    /*
+       String inputFile = "/Users/ziegler/Desktop/Work/Files/Data/ENG/central_2348_uncookedSkim.hipo";
         //String inputFile = "/Users/ziegler/Desktop/Work/Files/Data/skim_clas_002436.evio.90.hipo";
 //String inputFile="/Users/ziegler/Desktop/Work/Files/LumiRuns/random/decoded_2341.hipo";
         System.err.println(" \n[PROCESSING FILE] : " + inputFile);
@@ -445,7 +193,7 @@ public class CVTReconstruction extends ReconstructionEngine {
         HipoDataSync writer = new HipoDataSync();
         //Writer
         //String outputFile = "/Users/ziegler/Desktop/Work/Files/Data/ENG/central_2348_cookedSkim.hipo";
-        String outputFile = "/Users/ziegler/Desktop/Work/Files/Data/DecodedData/CVT/svt123_003582.0.rec.hipo";
+        String outputFile = "/Users/ziegler/Desktop/Work/Files/Data/recook_clas_002436.evio.90.hipo";
         writer.open(outputFile);
 
         long t1 = 0;
@@ -463,13 +211,13 @@ public class CVTReconstruction extends ReconstructionEngine {
             en.processDataEvent(event);
             //eb.processDataEvent(event);
             
-            //if(event.hasBank("CVTRec::Tracks")) {
+            if(event.hasBank("CVTRec::Tracks")) {
             
                 writer.writeEvent(event); 
-            //}
+            }
             counter ++;
             
-            if(counter>10000)
+            if(counter>100000)
                 break;
             //if(event.getBank("RUN::config").getInt("event",0)>=2000) break;
             //event.show();
@@ -480,9 +228,11 @@ public class CVTReconstruction extends ReconstructionEngine {
         writer.close();
         double t = System.currentTimeMillis() - t1;
         //System.out.println(t1 + " TOTAL  PROCESSING TIME = " + (t / (float) counter));
-        
-        /*
-        DataEvent testEvent = getCVTTestEvent();
+        */
+        HipoDataSource reader = new HipoDataSource();
+        reader.open("/home/fbossu/Data/Tracking/sim/test/gen_cvt1.hipo");
+        DataEvent testEvent = reader.gotoEvent(2);
+//        DataEvent testEvent = getCVTTestEvent();
 
         CVTReconstruction CVTengine = new CVTReconstruction();
         CVTengine.init();
@@ -491,7 +241,7 @@ public class CVTReconstruction extends ReconstructionEngine {
         if(testEvent.hasBank("CVTRec::Tracks")) {
             testEvent.getBank("CVTRec::Tracks").show();
         }
-        */
+        
        /*
         EBHBEngine EBHBengine = new EBHBEngine();
         EBHBengine.init();

--- a/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/track/fit/KFitter.java
+++ b/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/track/fit/KFitter.java
@@ -23,6 +23,10 @@ public class KFitter {
 
     public StateVec finalStateVec;
 
+    public KFitter(Seed trk, org.jlab.rec.cvt.svt.Geometry geo) {
+        this.init(trk, geo, null);
+    }
+    
     public KFitter(Seed trk, org.jlab.rec.cvt.svt.Geometry geo, DataEvent event) {
         this.init(trk, geo, event);
     }


### PR DESCRIPTION
Changes:

- CVT service modified. Most of the code has been put in a separate class "CVTRecHandler", so that can be used also by other classes/analyses.

- An old fix to the old seeding algorithm

- small changes to CA seeder

- added a method to KFitter: init does not need the svt geo, but for retro-compatibility, the old one is still there