### PR TITLE
CVT tracking. Improvements to the algo and clone killing switched on.

### DIFF
--- a/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/cross/Cross.java
+++ b/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/cross/Cross.java
@@ -37,6 +37,8 @@ public class Cross extends ArrayList<Cluster> implements Comparable<Cross> {
         this._Sector = sector;
         this._Region = region;
         this._Id = crid;
+        this._usedInXYcand = false;
+        this._usedInZRcand = false;
     }
 
     private String _Detector;							//      the detector SVT or BMT
@@ -45,7 +47,26 @@ public class Cross extends ArrayList<Cluster> implements Comparable<Cross> {
     private int _Region;    		 					//	    region [1,...]
     private int _Id;									//		cross Id
 
-    // point parameters:
+    private boolean _usedInXYcand;   // used in patter recognition
+    private boolean _usedInZRcand;
+    
+    public boolean is_usedInXYcand() {
+		return _usedInXYcand;
+	}
+
+	public void set_usedInXYcand(boolean _usedInXYcand) {
+		this._usedInXYcand = _usedInXYcand;
+	}
+
+	public boolean is_usedInZRcand() {
+		return _usedInZRcand;
+	}
+
+	public void set_usedInZRcand(boolean _usedInZRcand) {
+		this._usedInZRcand = _usedInZRcand;
+	}
+
+	// point parameters:
     private Point3D _Point;
     private Point3D _PointErr;
     private Point3D _Point0;
@@ -457,9 +478,17 @@ public class Cross extends ArrayList<Cluster> implements Comparable<Cross> {
         	int argreg  = (arg.get_Detector().equalsIgnoreCase("BMT"))  ? 3 + bgeom.getLayer( arg.get_Region(), arg.get_DetectorType()) : arg.get_Region();
             int RegComp = thisreg < argreg ? -1 : thisreg == argreg ? 0 : 1;
 //            int RegComp = this.get_Region() < arg.get_Region() ? -1 : this.get_Region() == arg.get_Region() ? 0 : 1;
-            int PhiComp = this.get_Point0().toVector3D().phi() < arg.get_Point0().toVector3D().phi() ? -1 : this.get_Point0().toVector3D().phi() == arg.get_Point0().toVector3D().phi() ? 0 : 1;
-
-            return_val = ((RegComp == 0) ? PhiComp : RegComp);
+            
+            // check that is not BMTC for phi comparison
+            if( Double.isNaN(arg.get_Point().x())==false &&  Double.isNaN(this.get_Point().x())==false ) {
+            	int PhiComp = this.get_Point0().toVector3D().phi() < arg.get_Point0().toVector3D().phi() ? -1 : this.get_Point0().toVector3D().phi() == arg.get_Point0().toVector3D().phi() ? 0 : 1;
+            
+            	return_val = ((RegComp == 0) ? PhiComp : RegComp);
+            }
+            else {
+            	int ZComp = this.get_Point0().z() < arg.get_Point0().z() ? -1 : this.get_Point0().z() == arg.get_Point0().z() ? 0 : 1;
+            	return_val = ((RegComp == 0) ? ZComp : RegComp);
+            }
         }
 
         return return_val;

--- a/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/fit/HelicalTrackFitter.java
+++ b/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/fit/HelicalTrackFitter.java
@@ -163,7 +163,8 @@ public class HelicalTrackFitter {
         //fit_Z0 = (Math.abs(fit_dca)-_linefitpars.intercept())/ _linefitpars.slope() ; //reset for displaced vertex
         //System.out.println("fit z0 "+_linefitpars.intercept());
         //require vertex position inside of the inner barrel
-        if (Math.abs(fit_dca) > Constants.MODULERADIUS[0][0] || Math.abs(fit_Z0) > 100) {
+        if (Math.abs(fit_dca) > Constants.MODULERADIUS[0][0]) {
+//            if (Math.abs(fit_dca) > Constants.MODULERADIUS[0][0] || Math.abs(fit_Z0) > 100) {
             return null;
         }
 

--- a/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/track/Seed.java
+++ b/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/track/Seed.java
@@ -63,7 +63,8 @@ public class Seed implements Comparable<Seed>{
     @Override
     public int compareTo(Seed arg) {
 
-        return Double.parseDouble(this.get_IntIdentifier()) < Double.parseDouble(arg.get_IntIdentifier()) ? -1 : Double.parseDouble(this.get_IntIdentifier()) == Double.parseDouble(arg.get_IntIdentifier()) ? 0 : 1;
+    	return ( this._Crosses.size() > arg.get_Crosses().size() ) ? -1 : ( this._Crosses.size() == arg.get_Crosses().size() ) ? 0 : 1;
+//        return Double.parseDouble(this.get_IntIdentifier()) < Double.parseDouble(arg.get_IntIdentifier()) ? -1 : Double.parseDouble(this.get_IntIdentifier()) == Double.parseDouble(arg.get_IntIdentifier()) ? 0 : 1;
         
     }
 

--- a/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/track/Track.java
+++ b/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/track/Track.java
@@ -16,7 +16,7 @@ import org.jlab.rec.cvt.trajectory.Trajectory;
  * @author ziegler
  *
  */
-public class Track extends Trajectory {
+public class Track extends Trajectory implements Comparable<Track> {
 
     private int _TrackingStatus;
 
@@ -208,6 +208,37 @@ public class Track extends Trajectory {
         return isInTrack;
     }
 
+    @Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (!super.equals(obj))
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		Track other = (Track) obj;
+		if ( this.get_Id() != other.get_Id())
+			return false;
+
+		return true;
+	}
+
+
+
+    @Override
+    public int hashCode() {
+    	final int prime = 101;
+    	int result = super.hashCode();
+    	result += prime * result + this.get(0).hashCode() + this.get(this.size()-1).hashCode();
+    	return result;
+    }    
+    
+    @Override
+    public int compareTo( Track tr ) {
+//    	return ( tr.size() >= this.size() ) ? 1 : -1;
+    	return ( tr.get_P() > this.get_P() ) ? 1 : -1;
+    }
+    
     public Point3D get_TrackPointAtCTOFRadius() {
         return _TrackPointAtCTOFRadius;
     }

--- a/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/track/fit/KFitter.java
+++ b/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/track/fit/KFitter.java
@@ -138,7 +138,7 @@ public class KFitter {
             double pz = invKappa * sv.trackTraj.get(k).tanL;
             TrjPoints.add(new HitOnTrack(layer, x, y, z, px, py, pz));
 
-            //System.out.println(" Traj layer "+layer+" x "+x+" y "+y+" z "+z);
+//            System.out.println(" Traj layer "+layer+" x "+x+" y "+y+" z "+z);
         }
     }
 
@@ -187,19 +187,19 @@ public class KFitter {
                         this.setFitFailed = true;
                     }
                     //System.err.println(c.get_Cluster1().get_Layer()+") error in traj "+this.TrjPoints.size());
-                    if (Double.isNaN(c.get_Point().x())) {
-                        c.set_Point(new Point3D(h.x, h.y, c.get_Point().z()));
-                    }
-                    if (Double.isNaN(c.get_Point().z())) {
-                        c.set_Point(new Point3D(c.get_Point().x(), c.get_Point().y(), h.z));
-                    }
+//                    if (Double.isNaN(c.get_Point().x())) {
+//                        c.set_Point(new Point3D(h.x, h.y, c.get_Point().z()));
+//                    }
+//                    if (Double.isNaN(c.get_Point().z())) {
+//                        c.set_Point(new Point3D(c.get_Point().x(), c.get_Point().y(), h.z));
+//                    }
 
                 }
             }
         }
         cand.addAll(trk.get_Crosses());
 
-        cand.finalUpdate_Crosses(geo);
+//        cand.finalUpdate_Crosses(geo);
 
         return cand;
     }


### PR DESCRIPTION
Small fix:
- Trajectory filling fixed. Now the intersections with the detector planes is filled regardless of the presence of a cross in the plane. Duplicate entries in the trajectory also fixed.
- Cross's compareTo method improved to take into account same layer bmt crosses

- Cross position at the Track fixed for better display in CED.

New feature:
- Track now extend comparable and has a hashCode method. This allows one to simplify the search in arrays. Old methods will be removed in future.

- Clone killing. Candidates are considered clones if they share at least 2 crosses. Duplicate choice based on the largest number of crosses.