### PR TITLE
Set B-field values to hits resolved from LR ambiguity algo.

### DIFF
--- a/reconstruction/dc/src/main/java/org/jlab/rec/dc/banks/HitReader.java
+++ b/reconstruction/dc/src/main/java/org/jlab/rec/dc/banks/HitReader.java
@@ -321,7 +321,7 @@ public class HitReader {
             hit.set_QualityFac(0);
             //hit.set_Doca(hit.get_TimeToDistance());
             //if (hit.get_Doca() > hit.get_CellSize() || hit.get_Time()>CCDBConstants.getTMAXSUPERLAYER()[hit.get_Sector()-1][hit.get_Superlayer()-1] ) {
-            if (hit.get_Doca() > hit.get_CellSize() || hit.get_Time() > constants1.getDoubleValue("tmax", hit.get_Sector(), hit.get_Superlayer(),0) ) {
+            if (hit.get_Doca() > hit.get_CellSize() ) {
                 //this.fix_TimeToDistance(this.get_CellSize());
                 hit.set_OutOfTimeFlag(true);
                 hit.set_QualityFac(2);
@@ -421,7 +421,7 @@ public class HitReader {
             hit.set_QualityFac(0);
             //hit.set_Doca(hit.get_TimeToDistance());
             //if (hit.get_Doca() > hit.get_CellSize() || hit.get_Time()>CCDBConstants.getTMAXSUPERLAYER()[hit.get_Sector()-1][hit.get_Superlayer()-1]) {
-            if (hit.get_Doca() > hit.get_CellSize() || hit.get_Time()>constants1.getDoubleValue("tmax", hit.get_Sector(), hit.get_Superlayer(),0) ) {   
+            if (hit.get_Doca() > hit.get_CellSize() ) {   
                 //this.fix_TimeToDistance(this.get_CellSize());
                 hit.set_OutOfTimeFlag(true);
                 hit.set_QualityFac(2);

--- a/reconstruction/dc/src/main/java/org/jlab/rec/dc/cluster/ClusterCleanerUtilities.java
+++ b/reconstruction/dc/src/main/java/org/jlab/rec/dc/cluster/ClusterCleanerUtilities.java
@@ -370,6 +370,7 @@ public class ClusterCleanerUtilities {
             newhitPos.set_DocaErr(hit.get_DocaErr());
             newhitPos.setT0(hit.getT0()); 
             newhitPos.set_Beta(hit.get_Beta()); 
+            newhitPos.setB(hit.getB()); 
             newhitPos.set_DeltaTimeBeta(hit.get_DeltaTimeBeta());
             newhitPos.setTStart(hit.getTStart());
             newhitPos.setTProp(hit.getTProp());
@@ -390,6 +391,7 @@ public class ClusterCleanerUtilities {
             newhitNeg.set_DocaErr(hit.get_DocaErr());
             newhitNeg.setT0(hit.getT0()); 
             newhitNeg.set_Beta(hit.get_Beta());  
+            newhitNeg.setB(hit.getB());  
             newhitNeg.set_DeltaTimeBeta(hit.get_DeltaTimeBeta());
             newhitNeg.setTStart(hit.getTStart());
             newhitNeg.setTProp(hit.getTProp());

--- a/reconstruction/dc/src/main/java/org/jlab/rec/dc/cluster/ClusterFinder.java
+++ b/reconstruction/dc/src/main/java/org/jlab/rec/dc/cluster/ClusterFinder.java
@@ -371,7 +371,8 @@ public class ClusterFinder {
                         newhit.set_Doca(hit.get_Doca());
                         newhit.set_DocaErr(hit.get_DocaErr());
                         newhit.setT0(hit.getT0()); 
-                        newhit.set_Beta(hit.get_Beta()); 
+                        newhit.set_Beta(hit.get_Beta());
+                        newhit.setB(hit.getB());
                         newhit.set_DeltaTimeBeta(hit.get_DeltaTimeBeta());
                         newhit.setTStart(hit.getTStart());
                         newhit.setTProp(hit.getTProp());

--- a/reconstruction/dc/src/main/java/org/jlab/rec/dc/timetodistance/TimeToDistanceEstimator.java
+++ b/reconstruction/dc/src/main/java/org/jlab/rec/dc/timetodistance/TimeToDistanceEstimator.java
@@ -43,7 +43,7 @@ public class TimeToDistanceEstimator {
         if(B>3.0) {
             B=3.0;
         }
-
+        
         int binlowB  = this.getBIdx(B);
         int binhighB = binlowB + 1; 
 

--- a/reconstruction/dc/src/main/java/org/jlab/service/dc/DCHBEngine.java
+++ b/reconstruction/dc/src/main/java/org/jlab/service/dc/DCHBEngine.java
@@ -303,7 +303,7 @@ public class DCHBEngine extends DCEngine {
         //String inputFile="/Users/ziegler/Desktop/Work/Files/Data/DecodedData/clas_003305.hipo";
         //String inputFile="/Users/ziegler/Desktop/Work/validation/infiles/out_clas_004013.evio.filt.hipo";
         //String inputFile="/Users/ziegler/Desktop/Work/Files/GEMC/BGMERG/gemc_out_mu-_hipo/mu-_30nA_bg_out.ev.hipo";
-         String inputFile="/Users/ziegler/Desktop/Work/Files/GEMC/straight.hipo";
+         String inputFile="/Users/ziegler/Desktop/Work/Files/Data/out_clas_002391_extractRawBanksFromCooked.hipo";
         //String inputFile="/Users/ziegler/Desktop/Work/Files/FMTDevel/gemc/pion_rec.hipo";
         //System.err.println(" \n[PROCESSING FILE] : " + inputFile);
         
@@ -323,7 +323,7 @@ public class DCHBEngine extends DCEngine {
         
         //String outputFile="/Users/ziegler/Desktop/Work/Files/Data/DecodedData/clas_003305_recGDSt.hipo";
        // String outputFile="/Users/ziegler/Desktop/Work/validation/outfiles/out_clas_004013.evio.filtRecookSinThread.hipo";
-        String outputFile="/Users/ziegler/Desktop/Work/Files/GEMC/straight_rec.hipo";
+        String outputFile="/Users/ziegler/Desktop/Work/Files/Data/out_clas_002391_extractRawBanksFromCookedReCook.hipo";
         //String outputFile="/Users/ziegler/Desktop/Work/Files/FMTDevel/gemc/pion_recFMTClusNoTrkRefit.hipo";
         
         writer.open(outputFile);


### PR DESCRIPTION
I think that the issue observed in the doca vs time plot is due to hits with reset LR ambiguity for which the B-field information did not get persisted.  This fix ensures this.  The status=2 for times greater that tmax is removed.  I would like to test this code for calibrations.