### PR TITLE
Fix beta cut in TBT

### DIFF
--- a/reconstruction/dc/src/main/java/org/jlab/rec/dc/banks/HitReader.java
+++ b/reconstruction/dc/src/main/java/org/jlab/rec/dc/banks/HitReader.java
@@ -304,7 +304,8 @@ public class HitReader {
             hit.setTProp(tProp[i]);
             hit.setTFlight(tFlight[i]);
             hit.set_Beta(this.readBeta(event, trkID[i])); 
-            
+            if(hit.get_Beta()>1.0)
+                hit.set_Beta(1.0); // HB resolution too poor to set cut on beta.
             double T0Sub = (double) (tdc[i] - tProp[i] - tFlight[i] - T_0);
             
             if(Constants.isUSETSTART()==true) { 

--- a/reconstruction/dc/src/main/java/org/jlab/rec/dc/banks/HitReader.java
+++ b/reconstruction/dc/src/main/java/org/jlab/rec/dc/banks/HitReader.java
@@ -304,8 +304,7 @@ public class HitReader {
             hit.setTProp(tProp[i]);
             hit.setTFlight(tFlight[i]);
             hit.set_Beta(this.readBeta(event, trkID[i])); 
-            if(hit.get_Beta()>1.0)
-                hit.set_Beta(1.0); // HB resolution too poor to set cut on beta.
+            
             double T0Sub = (double) (tdc[i] - tProp[i] - tFlight[i] - T_0);
             
             if(Constants.isUSETSTART()==true) { 
@@ -333,8 +332,11 @@ public class HitReader {
             hit.set_DocaErr(hit.get_PosErr(B[i], constants0, constants1, tde));            
             hit.set_AssociatedClusterID(clusterID[i]);
             hit.set_AssociatedHBTrackID(trkID[i]); 
-            if(hit.get_Beta()>0.1 && hit.get_Beta()<=1.00) 
+            if(hit.get_Beta()>0.15 && hit.get_Beta()<=1.40) {
+                if(hit.get_Beta()>1.0)
+                    hit.set_Beta(1.0);
                 hits.add(hit);
+            }
         }
         
         this.set_HBHits(hits);
@@ -429,7 +431,9 @@ public class HitReader {
             } 
             if(hit.get_Time()<0)
                 hit.set_QualityFac(1);
-            if(hit.get_Beta()>0.1 && hit.get_Beta()<=1.00) 
+            if(hit.get_Beta()>0.2 && hit.get_Beta()<=1.30)
+                if(hit.get_Beta()>1.0)
+                    hit.set_Beta(1.0);
                 hits.add(hit);
             hits.add(hit);
             


### PR DESCRIPTION
Set the cut on beta for HB HOTs to beta>0.15, beta<1.4; TB HOTs to beta>0.2, beta<1.3. Resets beta larger than 1 to 1.0 in T2D calculation assuming e- hypothesis.