### PR TITLE
Update scripts to use environment variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ sudo: required
 
 language: java
 
+env:
+    - CLAS12DIR /home/travis/build/JeffersonLab/clas12-offline-software/coatjava
+
 jdk:
 - oraclejdk8
 

--- a/bin/analyzer
+++ b/bin/analyzer
@@ -7,10 +7,6 @@ YELLOW='\033[0;33m'       # Yellow
 BLUE='\033[0;34m'         # Blue
 PURPLE='\033[0;35m'       # Purple
 
-export MALLOC_ARENA_MAX=1
-export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
-export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
-
 if [ -z ${CLAS12DIR+x} ];
   then
     if [ -z ${CLARA_HOME+x} ];
@@ -37,5 +33,6 @@ if [ -z ${CLAS12DIR+x} ];
     echo +-------------------------------------------------------------------------
     echo -en "${NC}";
 fi
+source $CLAS12DIR/bin/env.sh
 
 java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.clas.physics.DataAnalysis $*

--- a/bin/analyzer
+++ b/bin/analyzer
@@ -1,19 +1,41 @@
-#!/bin/sh -f
+#!/bin/bash
 
-source `dirname $0`/env.sh 
+NC='\033[0m'              # No Color
+RED='\033[0;31m'          # Red
+GREEN='\033[0;32m'        # Green
+YELLOW='\033[0;33m'       # Yellow
+BLUE='\033[0;34m'         # Blue
+PURPLE='\033[0;35m'       # Purple
 
-#CLARA_HOME=`dirname $0`
-#CLARA_SERVICES=`dirname $0`
-#DATAMINING=`dirname $0`
+export MALLOC_ARENA_MAX=1
+export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
+export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
 
-echo +-------------------------------------------------------------------------
-echo "| Starting CLARA-PLATFORM with CLARA_SERVICES = " $CLARA_SERVICES
-echo +-------------------------------------------------------------------------
-echo "\n"
+if [ -z ${CLAS12DIR+x} ];
+  then
+    if [ -z ${CLARA_HOME+x} ];
+      then
+        echo -en "${RED}";
+        echo "Error: CLAS12DIR and CLARA_HOME not set.";
+        echo "Set one of these to continue";
+        echo "Exiting";
+        echo -en "${NC}";
+        exit 1;
+      else
+        export CLARA_SERVICES=$CLARA_HOME/lib;
+        export CLAS12DIR=$CLARA_HOME/plugins/clas12;
+        echo -en "${GREEN}";
+        echo +-------------------------------------------------------------------------
+        echo "| Using CLARA_SERVICES to set CLAS12DIR: $CLAS12DIR";
+        echo +-------------------------------------------------------------------------
+        echo -en "${NC}";
+    fi
+  else
+    echo -en "${GREEN}";
+    echo +-------------------------------------------------------------------------
+    echo "| Using CLAS12DIR, manually set to: $CLAS12DIR";
+    echo +-------------------------------------------------------------------------
+    echo -en "${NC}";
+fi
 
-echo "INSTALLATION DIRECTORY = " $CLARA_HOME
-echo "LIBRARY DIRECTORY      = " $DATAMINING/lib/clas/
-
-#java -cp "$DATAMINING/lib/clas/core/*" org.jlab.coda.eventViewer.EventTreeFrame $*
-#java -Xms1024m -cp "$DATAMINING/lib/clas/*:$DATAMINING/lib/plugins/*" org.jlab.io.hipo.HipoDataSync $*
-java -Xms1024m -cp "$DATAMINING/lib/clas/*:$DATAMINING/lib/plugins/*" org.jlab.clas.physics.DataAnalysis $*
+java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.clas.physics.DataAnalysis $*

--- a/bin/bos2hipo
+++ b/bin/bos2hipo
@@ -1,19 +1,41 @@
-#!/bin/sh -f
+#!/bin/bash
 
-source `dirname $0`/env.sh 
+NC='\033[0m'              # No Color
+RED='\033[0;31m'          # Red
+GREEN='\033[0;32m'        # Green
+YELLOW='\033[0;33m'       # Yellow
+BLUE='\033[0;34m'         # Blue
+PURPLE='\033[0;35m'       # Purple
 
-#CLARA_HOME=`dirname $0`
-#CLARA_SERVICES=`dirname $0`
-#DATAMINING=`dirname $0`
+export MALLOC_ARENA_MAX=1
+export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
+export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
 
-echo +-------------------------------------------------------------------------
-echo "| Starting CLARA-PLATFORM with CLARA_SERVICES = " $CLARA_SERVICES
-echo +-------------------------------------------------------------------------
-echo "\n"
+if [ -z ${CLAS12DIR+x} ];
+  then
+    if [ -z ${CLARA_HOME+x} ];
+      then
+        echo -en "${RED}";
+        echo "Error: CLAS12DIR and CLARA_HOME not set.";
+        echo "Set one of these to continue";
+        echo "Exiting";
+        echo -en "${NC}";
+        exit 1;
+      else
+        export CLARA_SERVICES=$CLARA_HOME/lib;
+        export CLAS12DIR=$CLARA_HOME/plugins/clas12;
+        echo -en "${GREEN}";
+        echo +-------------------------------------------------------------------------
+        echo "| Using CLARA_SERVICES to set CLAS12DIR: $CLAS12DIR";
+        echo +-------------------------------------------------------------------------
+        echo -en "${NC}";
+    fi
+  else
+    echo -en "${GREEN}";
+    echo +-------------------------------------------------------------------------
+    echo "| Using CLAS12DIR, manually set to: $CLAS12DIR";
+    echo +-------------------------------------------------------------------------
+    echo -en "${NC}";
+fi
 
-echo "INSTALLATION DIRECTORY = " $CLARA_HOME
-echo "LIBRARY DIRECTORY      = " $DATAMINING/lib/clas/
-
-#java -cp "$DATAMINING/lib/clas/core/*" org.jlab.coda.eventViewer.EventTreeFrame $*
-#java -Xms1024m -cp "$DATAMINING/lib/clas/*:$DATAMINING/lib/plugins/*" org.jlab.io.hipo.HipoDataSync $*
-java -Xms1024m -cp "$DATAMINING/lib/clas/*:$DATAMINING/lib/plugins/*" org.jlab.io.utils.Bos2HipoEventBank $*
+java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.io.utils.Bos2HipoEventBank $*

--- a/bin/bos2hipo
+++ b/bin/bos2hipo
@@ -7,10 +7,6 @@ YELLOW='\033[0;33m'       # Yellow
 BLUE='\033[0;34m'         # Blue
 PURPLE='\033[0;35m'       # Purple
 
-export MALLOC_ARENA_MAX=1
-export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
-export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
-
 if [ -z ${CLAS12DIR+x} ];
   then
     if [ -z ${CLARA_HOME+x} ];
@@ -37,5 +33,6 @@ if [ -z ${CLAS12DIR+x} ];
     echo +-------------------------------------------------------------------------
     echo -en "${NC}";
 fi
+source $CLAS12DIR/bin/env.sh
 
 java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.io.utils.Bos2HipoEventBank $*

--- a/bin/browser
+++ b/bin/browser
@@ -1,18 +1,41 @@
-#!/bin/sh -f
+#!/bin/bash
 
-source `dirname $0`/env.sh 
+NC='\033[0m'              # No Color
+RED='\033[0;31m'          # Red
+GREEN='\033[0;32m'        # Green
+YELLOW='\033[0;33m'       # Yellow
+BLUE='\033[0;34m'         # Blue
+PURPLE='\033[0;35m'       # Purple
 
-#CLARA_HOME=`dirname $0`
-#CLARA_SERVICES=`dirname $0`
-#DATAMINING=`dirname $0`
+export MALLOC_ARENA_MAX=1
+export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
+export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
 
-echo +-------------------------------------------------------------------------
-echo "| Starting CLARA-PLATFORM with CLARA_SERVICES = " $CLARA_SERVICES
-echo +-------------------------------------------------------------------------
-echo "\n"
+if [ -z ${CLAS12DIR+x} ];
+  then
+    if [ -z ${CLARA_HOME+x} ];
+      then
+        echo -en "${RED}";
+        echo "Error: CLAS12DIR and CLARA_HOME not set.";
+        echo "Set one of these to continue";
+        echo "Exiting";
+        echo -en "${NC}";
+        exit 1;
+      else
+        export CLARA_SERVICES=$CLARA_HOME/lib;
+        export CLAS12DIR=$CLARA_HOME/plugins/clas12;
+        echo -en "${GREEN}";
+        echo +-------------------------------------------------------------------------
+        echo "| Using CLARA_SERVICES to set CLAS12DIR: $CLAS12DIR";
+        echo +-------------------------------------------------------------------------
+        echo -en "${NC}";
+    fi
+  else
+    echo -en "${GREEN}";
+    echo +-------------------------------------------------------------------------
+    echo "| Using CLAS12DIR, manually set to: $CLAS12DIR";
+    echo +-------------------------------------------------------------------------
+    echo -en "${NC}";
+fi
 
-echo "INSTALLATION DIRECTORY = " $CLARA_HOME
-echo "LIBRARY DIRECTORY      = " $DATAMINING/lib/clas/
-
-#java -cp "$DATAMINING/lib/clas/core/*" org.jlab.coda.eventViewer.EventTreeFrame $*
-java -Xms1024m -cp "$DATAMINING/lib/clas/*:$DATAMINING/lib/plugins/*" org.jlab.groot.ui.TBrowser $*
+java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.groot.ui.TBrowser $*

--- a/bin/browser
+++ b/bin/browser
@@ -7,10 +7,6 @@ YELLOW='\033[0;33m'       # Yellow
 BLUE='\033[0;34m'         # Blue
 PURPLE='\033[0;35m'       # Purple
 
-export MALLOC_ARENA_MAX=1
-export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
-export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
-
 if [ -z ${CLAS12DIR+x} ];
   then
     if [ -z ${CLARA_HOME+x} ];
@@ -37,5 +33,6 @@ if [ -z ${CLAS12DIR+x} ];
     echo +-------------------------------------------------------------------------
     echo -en "${NC}";
 fi
+source $CLAS12DIR/bin/env.sh
 
 java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.groot.ui.TBrowser $*

--- a/bin/calibration
+++ b/bin/calibration
@@ -1,20 +1,41 @@
-#!/bin/sh -f
+#!/bin/bash
 
-source `dirname $0`/env.sh 
+NC='\033[0m'              # No Color
+RED='\033[0;31m'          # Red
+GREEN='\033[0;32m'        # Green
+YELLOW='\033[0;33m'       # Yellow
+BLUE='\033[0;34m'         # Blue
+PURPLE='\033[0;35m'       # Purple
 
-#CLARA_HOME=`dirname $0`
-#CLARA_SERVICES=`dirname $0`
-#DATAMINING=`dirname $0`
+export MALLOC_ARENA_MAX=1
+export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
+export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
 
-echo +-------------------------------------------------------------------------
-echo "| Starting CLARA-PLATFORM with CLARA_SERVICES = " $CLARA_SERVICES
-echo +-------------------------------------------------------------------------
-echo "\n"
+if [ -z ${CLAS12DIR+x} ];
+  then
+    if [ -z ${CLARA_HOME+x} ];
+      then
+        echo -en "${RED}";
+        echo "Error: CLAS12DIR and CLARA_HOME not set.";
+        echo "Set one of these to continue";
+        echo "Exiting";
+        echo -en "${NC}";
+        exit 1;
+      else
+        export CLARA_SERVICES=$CLARA_HOME/lib;
+        export CLAS12DIR=$CLARA_HOME/plugins/clas12;
+        echo -en "${GREEN}";
+        echo +-------------------------------------------------------------------------
+        echo "| Using CLARA_SERVICES to set CLAS12DIR: $CLAS12DIR";
+        echo +-------------------------------------------------------------------------
+        echo -en "${NC}";
+    fi
+  else
+    echo -en "${GREEN}";
+    echo +-------------------------------------------------------------------------
+    echo "| Using CLAS12DIR, manually set to: $CLAS12DIR";
+    echo +-------------------------------------------------------------------------
+    echo -en "${NC}";
+fi
 
-echo "INSTALLATION DIRECTORY = " $CLARA_HOME
-echo "LIBRARY DIRECTORY      = " $DATAMINING/lib/clas/
-
-#java -cp "$DATAMINING/lib/clas/core/*" org.jlab.coda.eventViewer.EventTreeFrame $*
-#java -XX:+UseSerialGC -Xms1024m -cp "$DATAMINING/lib/clas/*:$DATAMINING/lib/plugins/*" org.jlab.clasrec.rec.CLASReconstruction $*
-#java -XX:+UseSerialGC -Xmx2048m -Xms2048m -cp "$DATAMINING/lib/clas/*:$DATAMINING/lib/plugins/*" org.jlab.detector.calib.tasks.CalibrationEngineTask $*
-java -XX:+UseSerialGC -Xmx2048m -Xms2048m -cp "$DATAMINING/lib/clas/*:$DATAMINING/lib/plugins/*" org.jlab.calib.services.TOFCalibration $*
+java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.calib.services.TOFCalibration $*

--- a/bin/calibration
+++ b/bin/calibration
@@ -7,10 +7,6 @@ YELLOW='\033[0;33m'       # Yellow
 BLUE='\033[0;34m'         # Blue
 PURPLE='\033[0;35m'       # Purple
 
-export MALLOC_ARENA_MAX=1
-export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
-export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
-
 if [ -z ${CLAS12DIR+x} ];
   then
     if [ -z ${CLARA_HOME+x} ];
@@ -37,5 +33,6 @@ if [ -z ${CLAS12DIR+x} ];
     echo +-------------------------------------------------------------------------
     echo -en "${NC}";
 fi
+source $CLAS12DIR/bin/env.sh
 
 java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.calib.services.TOFCalibration $*

--- a/bin/convertor
+++ b/bin/convertor
@@ -7,10 +7,6 @@ YELLOW='\033[0;33m'       # Yellow
 BLUE='\033[0;34m'         # Blue
 PURPLE='\033[0;35m'       # Purple
 
-export MALLOC_ARENA_MAX=1
-export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
-export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
-
 if [ -z ${CLAS12DIR+x} ];
   then
     if [ -z ${CLARA_HOME+x} ];
@@ -37,5 +33,6 @@ if [ -z ${CLAS12DIR+x} ];
     echo +-------------------------------------------------------------------------
     echo -en "${NC}";
 fi
+source $CLAS12DIR/bin/env.sh
 
 java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.clas.reco.io.HipoConvertor $*

--- a/bin/convertor
+++ b/bin/convertor
@@ -1,19 +1,41 @@
-#!/bin/sh -f
+#!/bin/bash
 
-source `dirname $0`/env.sh 
+NC='\033[0m'              # No Color
+RED='\033[0;31m'          # Red
+GREEN='\033[0;32m'        # Green
+YELLOW='\033[0;33m'       # Yellow
+BLUE='\033[0;34m'         # Blue
+PURPLE='\033[0;35m'       # Purple
 
-#CLARA_HOME=`dirname $0`
-#CLARA_SERVICES=`dirname $0`
-#DATAMINING=`dirname $0`
+export MALLOC_ARENA_MAX=1
+export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
+export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
 
-echo +-------------------------------------------------------------------------
-echo "| Starting CLARA-PLATFORM with CLARA_SERVICES = " $CLARA_SERVICES
-echo +-------------------------------------------------------------------------
-echo "\n"
+if [ -z ${CLAS12DIR+x} ];
+  then
+    if [ -z ${CLARA_HOME+x} ];
+      then
+        echo -en "${RED}";
+        echo "Error: CLAS12DIR and CLARA_HOME not set.";
+        echo "Set one of these to continue";
+        echo "Exiting";
+        echo -en "${NC}";
+        exit 1;
+      else
+        export CLARA_SERVICES=$CLARA_HOME/lib;
+        export CLAS12DIR=$CLARA_HOME/plugins/clas12;
+        echo -en "${GREEN}";
+        echo +-------------------------------------------------------------------------
+        echo "| Using CLARA_SERVICES to set CLAS12DIR: $CLAS12DIR";
+        echo +-------------------------------------------------------------------------
+        echo -en "${NC}";
+    fi
+  else
+    echo -en "${GREEN}";
+    echo +-------------------------------------------------------------------------
+    echo "| Using CLAS12DIR, manually set to: $CLAS12DIR";
+    echo +-------------------------------------------------------------------------
+    echo -en "${NC}";
+fi
 
-echo "INSTALLATION DIRECTORY = " $CLARA_HOME
-echo "LIBRARY DIRECTORY      = " $DATAMINING/lib/clas/
-
-#java -cp "$DATAMINING/lib/clas/core/*" org.jlab.coda.eventViewer.EventTreeFrame $*
-#java -Xms1024m -cp "$DATAMINING/lib/clas/*:$DATAMINING/lib/plugins/*" org.jlab.io.hipo.HipoDataSync $*
-java -Xms1024m -cp "$DATAMINING/lib/clas/*:$DATAMINING/lib/plugins/*" org.jlab.clas.reco.io.HipoConvertor $*
+java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.clas.reco.io.HipoConvertor $*

--- a/bin/daq-monitor
+++ b/bin/daq-monitor
@@ -7,10 +7,6 @@ YELLOW='\033[0;33m'       # Yellow
 BLUE='\033[0;34m'         # Blue
 PURPLE='\033[0;35m'       # Purple
 
-export MALLOC_ARENA_MAX=1
-export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
-export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
-
 if [ -z ${CLAS12DIR+x} ];
   then
     if [ -z ${CLARA_HOME+x} ];
@@ -37,5 +33,6 @@ if [ -z ${CLAS12DIR+x} ];
     echo +-------------------------------------------------------------------------
     echo -en "${NC}";
 fi
+source $CLAS12DIR/bin/env.sh
 
 java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.detector.examples.DaqPulsePlotter $*

--- a/bin/daq-monitor
+++ b/bin/daq-monitor
@@ -1,18 +1,41 @@
-#!/bin/sh -f
+#!/bin/bash
 
-source `dirname $0`/env.sh 
+NC='\033[0m'              # No Color
+RED='\033[0;31m'          # Red
+GREEN='\033[0;32m'        # Green
+YELLOW='\033[0;33m'       # Yellow
+BLUE='\033[0;34m'         # Blue
+PURPLE='\033[0;35m'       # Purple
 
-#CLARA_HOME=`dirname $0`
-#CLARA_SERVICES=`dirname $0`
-#DATAMINING=`dirname $0`
+export MALLOC_ARENA_MAX=1
+export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
+export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
 
-echo +-------------------------------------------------------------------------
-echo "| Starting CLARA-PLATFORM with CLARA_SERVICES = " $CLARA_SERVICES
-echo +-------------------------------------------------------------------------
-echo "\n"
+if [ -z ${CLAS12DIR+x} ];
+  then
+    if [ -z ${CLARA_HOME+x} ];
+      then
+        echo -en "${RED}";
+        echo "Error: CLAS12DIR and CLARA_HOME not set.";
+        echo "Set one of these to continue";
+        echo "Exiting";
+        echo -en "${NC}";
+        exit 1;
+      else
+        export CLARA_SERVICES=$CLARA_HOME/lib;
+        export CLAS12DIR=$CLARA_HOME/plugins/clas12;
+        echo -en "${GREEN}";
+        echo +-------------------------------------------------------------------------
+        echo "| Using CLARA_SERVICES to set CLAS12DIR: $CLAS12DIR";
+        echo +-------------------------------------------------------------------------
+        echo -en "${NC}";
+    fi
+  else
+    echo -en "${GREEN}";
+    echo +-------------------------------------------------------------------------
+    echo "| Using CLAS12DIR, manually set to: $CLAS12DIR";
+    echo +-------------------------------------------------------------------------
+    echo -en "${NC}";
+fi
 
-echo "INSTALLATION DIRECTORY = " $CLARA_HOME
-echo "LIBRARY DIRECTORY      = " $DATAMINING/lib/clas/
-
-#java -cp "$DATAMINING/lib/clas/core/*" org.jlab.coda.eventViewer.EventTreeFrame $*
-java -Xms1024m -cp "$DATAMINING/lib/clas/*:$DATAMINING/lib/services/*:$DATAMINING/lib/utils/*" org.jlab.detector.examples.DaqPulsePlotter $*
+java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.detector.examples.DaqPulsePlotter $*

--- a/bin/daqEventViewer
+++ b/bin/daqEventViewer
@@ -1,18 +1,41 @@
-#!/bin/sh -f
+#!/bin/bash
 
-source `dirname $0`/env.sh 
+NC='\033[0m'              # No Color
+RED='\033[0;31m'          # Red
+GREEN='\033[0;32m'        # Green
+YELLOW='\033[0;33m'       # Yellow
+BLUE='\033[0;34m'         # Blue
+PURPLE='\033[0;35m'       # Purple
 
-#CLARA_HOME=`dirname $0`
-#CLARA_SERVICES=`dirname $0`
-#DATAMINING=`dirname $0`
+export MALLOC_ARENA_MAX=1
+export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
+export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
 
-echo +-------------------------------------------------------------------------
-echo "| Starting CLARA-PLATFORM with CLARA_SERVICES = " $CLARA_SERVICES
-echo +-------------------------------------------------------------------------
-echo "\n"
+if [ -z ${CLAS12DIR+x} ];
+  then
+    if [ -z ${CLARA_HOME+x} ];
+      then
+        echo -en "${RED}";
+        echo "Error: CLAS12DIR and CLARA_HOME not set.";
+        echo "Set one of these to continue";
+        echo "Exiting";
+        echo -en "${NC}";
+        exit 1;
+      else
+        export CLARA_SERVICES=$CLARA_HOME/lib;
+        export CLAS12DIR=$CLARA_HOME/plugins/clas12;
+        echo -en "${GREEN}";
+        echo +-------------------------------------------------------------------------
+        echo "| Using CLARA_SERVICES to set CLAS12DIR: $CLAS12DIR";
+        echo +-------------------------------------------------------------------------
+        echo -en "${NC}";
+    fi
+  else
+    echo -en "${GREEN}";
+    echo +-------------------------------------------------------------------------
+    echo "| Using CLAS12DIR, manually set to: $CLAS12DIR";
+    echo +-------------------------------------------------------------------------
+    echo -en "${NC}";
+fi
 
-echo "INSTALLATION DIRECTORY = " $CLARA_HOME
-echo "LIBRARY DIRECTORY      = " $DATAMINING/lib/clas/
-
-#java -cp "$DATAMINING/lib/clas/core/*" org.jlab.coda.eventViewer.EventTreeFrame $*
-java -Xms1024m -cp "$DATAMINING/lib/clas/*:$DATAMINING/lib/services/*:$DATAMINING/lib/utils/*" org.jlab.detector.examples.RawEventViewer $*
+java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.detector.examples.RawEventViewer $*

--- a/bin/daqEventViewer
+++ b/bin/daqEventViewer
@@ -7,10 +7,6 @@ YELLOW='\033[0;33m'       # Yellow
 BLUE='\033[0;34m'         # Blue
 PURPLE='\033[0;35m'       # Purple
 
-export MALLOC_ARENA_MAX=1
-export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
-export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
-
 if [ -z ${CLAS12DIR+x} ];
   then
     if [ -z ${CLARA_HOME+x} ];
@@ -37,5 +33,6 @@ if [ -z ${CLAS12DIR+x} ];
     echo +-------------------------------------------------------------------------
     echo -en "${NC}";
 fi
+source $CLAS12DIR/bin/env.sh
 
 java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.detector.examples.RawEventViewer $*

--- a/bin/ddr
+++ b/bin/ddr
@@ -7,10 +7,6 @@ YELLOW='\033[0;33m'       # Yellow
 BLUE='\033[0;34m'         # Blue
 PURPLE='\033[0;35m'       # Purple
 
-export MALLOC_ARENA_MAX=1
-export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
-export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
-
 if [ -z ${CLAS12DIR+x} ];
   then
     if [ -z ${CLARA_HOME+x} ];
@@ -37,5 +33,6 @@ if [ -z ${CLAS12DIR+x} ];
     echo +-------------------------------------------------------------------------
     echo -en "${NC}";
 fi
+source $CLAS12DIR/bin/env.sh
 
 java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.clas.service.DataDistributionService -type et -host localhost -file /tmp/et_sys_$SESSION

--- a/bin/ddr
+++ b/bin/ddr
@@ -1,21 +1,41 @@
-#!/bin/sh -f
+#!/bin/bash
 
-source `dirname $0`/env.sh 
+NC='\033[0m'              # No Color
+RED='\033[0;31m'          # Red
+GREEN='\033[0;32m'        # Green
+YELLOW='\033[0;33m'       # Yellow
+BLUE='\033[0;34m'         # Blue
+PURPLE='\033[0;35m'       # Purple
 
-#CLARA_HOME=`dirname $0`
-#CLARA_SERVICES=`dirname $0`
-#DATAMINING=`dirname $0`
+export MALLOC_ARENA_MAX=1
+export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
+export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
 
-echo +-------------------------------------------------------------------------
-echo "| Starting CLARA-PLATFORM with CLARA_SERVICES = " $CLARA_SERVICES
-echo +-------------------------------------------------------------------------
-echo "\n"
+if [ -z ${CLAS12DIR+x} ];
+  then
+    if [ -z ${CLARA_HOME+x} ];
+      then
+        echo -en "${RED}";
+        echo "Error: CLAS12DIR and CLARA_HOME not set.";
+        echo "Set one of these to continue";
+        echo "Exiting";
+        echo -en "${NC}";
+        exit 1;
+      else
+        export CLARA_SERVICES=$CLARA_HOME/lib;
+        export CLAS12DIR=$CLARA_HOME/plugins/clas12;
+        echo -en "${GREEN}";
+        echo +-------------------------------------------------------------------------
+        echo "| Using CLARA_SERVICES to set CLAS12DIR: $CLAS12DIR";
+        echo +-------------------------------------------------------------------------
+        echo -en "${NC}";
+    fi
+  else
+    echo -en "${GREEN}";
+    echo +-------------------------------------------------------------------------
+    echo "| Using CLAS12DIR, manually set to: $CLAS12DIR";
+    echo +-------------------------------------------------------------------------
+    echo -en "${NC}";
+fi
 
-echo "INSTALLATION DIRECTORY = " $CLARA_HOME
-echo "LIBRARY DIRECTORY      = " $DATAMINING/lib/clas/
-
-#java -cp "$DATAMINING/lib/clas/core/*" org.jlab.coda.eventViewer.EventTreeFrame $*
-#java -Xms1024m -cp "$DATAMINING/lib/clas/*:$DATAMINING/lib/plugins/*" org.jlab.io.hipo.HipoDataSync $*
-#java  -XX:+UseNUMA -XX:+UseBiasedLocking -cp "$DATAMINING/lib/clas/*:$DATAMINING/lib/plugins/*" org.jlab.coda.xmsg.sys.xMsgProxy &
-#java -cp "$DATAMINING/lib/clas/*:$DATAMINING/lib/plugins/*" org.jlab.coda.xmsg.sys.xMsgProxy
-java -Xms1024m -cp "$DATAMINING/lib/clas/*:$DATAMINING/lib/plugins/*" org.jlab.clas.service.DataDistributionService -type et -host localhost -file /tmp/et_sys_$SESSION
+java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.clas.service.DataDistributionService -type et -host localhost -file /tmp/et_sys_$SESSION

--- a/bin/debug_ec.sh
+++ b/bin/debug_ec.sh
@@ -7,10 +7,6 @@ YELLOW='\033[0;33m'       # Yellow
 BLUE='\033[0;34m'         # Blue
 PURPLE='\033[0;35m'       # Purple
 
-export MALLOC_ARENA_MAX=1
-export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
-export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
-
 if [ -z ${CLAS12DIR+x} ];
   then
     if [ -z ${CLARA_HOME+x} ];
@@ -37,5 +33,6 @@ if [ -z ${CLAS12DIR+x} ];
     echo +-------------------------------------------------------------------------
     echo -en "${NC}";
 fi
+source $CLAS12DIR/bin/env.sh
 
 java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.display.ec.ECPion $*

--- a/bin/debug_ec.sh
+++ b/bin/debug_ec.sh
@@ -1,18 +1,41 @@
-#!/bin/sh -f
+#!/bin/bash
 
-source `dirname $0`/env.sh 
+NC='\033[0m'              # No Color
+RED='\033[0;31m'          # Red
+GREEN='\033[0;32m'        # Green
+YELLOW='\033[0;33m'       # Yellow
+BLUE='\033[0;34m'         # Blue
+PURPLE='\033[0;35m'       # Purple
 
-#CLARA_HOME=`dirname $0`
-#CLARA_SERVICES=`dirname $0`
-#DATAMINING=`dirname $0`
+export MALLOC_ARENA_MAX=1
+export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
+export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
 
-echo +-------------------------------------------------------------------------
-echo "| Starting CLARA-PLATFORM with CLARA_SERVICES = " $CLARA_SERVICES
-echo +-------------------------------------------------------------------------
-echo "\n"
+if [ -z ${CLAS12DIR+x} ];
+  then
+    if [ -z ${CLARA_HOME+x} ];
+      then
+        echo -en "${RED}";
+        echo "Error: CLAS12DIR and CLARA_HOME not set.";
+        echo "Set one of these to continue";
+        echo "Exiting";
+        echo -en "${NC}";
+        exit 1;
+      else
+        export CLARA_SERVICES=$CLARA_HOME/lib;
+        export CLAS12DIR=$CLARA_HOME/plugins/clas12;
+        echo -en "${GREEN}";
+        echo +-------------------------------------------------------------------------
+        echo "| Using CLARA_SERVICES to set CLAS12DIR: $CLAS12DIR";
+        echo +-------------------------------------------------------------------------
+        echo -en "${NC}";
+    fi
+  else
+    echo -en "${GREEN}";
+    echo +-------------------------------------------------------------------------
+    echo "| Using CLAS12DIR, manually set to: $CLAS12DIR";
+    echo +-------------------------------------------------------------------------
+    echo -en "${NC}";
+fi
 
-echo "INSTALLATION DIRECTORY = " $CLARA_HOME
-echo "LIBRARY DIRECTORY      = " $DATAMINING/lib/clas/
-
-#java -cp "$DATAMINING/lib/clas/core/*" org.jlab.coda.eventViewer.EventTreeFrame $*
-java -Xms1024m -cp "$DATAMINING/lib/clas/*:$DATAMINING/lib/plugins/*" org.jlab.display.ec.ECPion $*
+java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.display.ec.ECPion $*

--- a/bin/decoder
+++ b/bin/decoder
@@ -1,22 +1,41 @@
 #!/bin/bash
 
-# This doesn't work in dash (Travis's /bin/sh):
-source `dirname $0`/env.sh 
+NC='\033[0m'              # No Color
+RED='\033[0;31m'          # Red
+GREEN='\033[0;32m'        # Green
+YELLOW='\033[0;33m'       # Yellow
+BLUE='\033[0;34m'         # Blue
+PURPLE='\033[0;35m'       # Purple
 
-MALLOC_ARENA_MAX=1; export MALLOC_ARENA_MAX
+export MALLOC_ARENA_MAX=1
+export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
+export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
 
-#CLARA_HOME=`dirname $0`
-#CLARA_SERVICES=`dirname $0`
-#DATAMINING=`dirname $0`
+if [ -z ${CLAS12DIR+x} ];
+  then
+    if [ -z ${CLARA_HOME+x} ];
+      then
+        echo -en "${RED}";
+        echo "Error: CLAS12DIR and CLARA_HOME not set.";
+        echo "Set one of these to continue";
+        echo "Exiting";
+        echo -en "${NC}";
+        exit 1;
+      else
+        export CLARA_SERVICES=$CLARA_HOME/lib;
+        export CLAS12DIR=$CLARA_HOME/plugins/clas12;
+        echo -en "${GREEN}";
+        echo +-------------------------------------------------------------------------
+        echo "| Using CLARA_SERVICES to set CLAS12DIR: $CLAS12DIR";
+        echo +-------------------------------------------------------------------------
+        echo -en "${NC}";
+    fi
+  else
+    echo -en "${GREEN}";
+    echo +-------------------------------------------------------------------------
+    echo "| Using CLAS12DIR, manually set to: $CLAS12DIR";
+    echo +-------------------------------------------------------------------------
+    echo -en "${NC}";
+fi
 
-echo +-------------------------------------------------------------------------
-echo "| Starting CLARA-PLATFORM with CLARA_SERVICES = " $CLARA_SERVICES
-echo +-------------------------------------------------------------------------
-echo "\n"
-
-echo "INSTALLATION DIRECTORY = " $CLARA_HOME
-echo "LIBRARY DIRECTORY      = " $DATAMINING/lib/clas/
-
-#java -cp "$DATAMINING/lib/clas/core/*" org.jlab.coda.eventViewer.EventTreeFrame $*
-#java -Xms1024m -cp "$DATAMINING/lib/clas/*:$DATAMINING/lib/plugins/*" org.jlab.io.hipo.HipoDataSync $*
-java -Xmx1536m -Xms1024m -cp "$DATAMINING/lib/clas/*:$DATAMINING/lib/plugins/*" org.jlab.detector.decode.CLASDecoder $*
+java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.detector.decode.CLASDecoder $*

--- a/bin/decoder
+++ b/bin/decoder
@@ -7,10 +7,6 @@ YELLOW='\033[0;33m'       # Yellow
 BLUE='\033[0;34m'         # Blue
 PURPLE='\033[0;35m'       # Purple
 
-export MALLOC_ARENA_MAX=1
-export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
-export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
-
 if [ -z ${CLAS12DIR+x} ];
   then
     if [ -z ${CLARA_HOME+x} ];
@@ -37,5 +33,6 @@ if [ -z ${CLAS12DIR+x} ];
     echo +-------------------------------------------------------------------------
     echo -en "${NC}";
 fi
+source $CLAS12DIR/bin/env.sh
 
 java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.detector.decode.CLASDecoder $*

--- a/bin/eb-monitor
+++ b/bin/eb-monitor
@@ -7,10 +7,6 @@ YELLOW='\033[0;33m'       # Yellow
 BLUE='\033[0;34m'         # Blue
 PURPLE='\033[0;35m'       # Purple
 
-export MALLOC_ARENA_MAX=1
-export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
-export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
-
 if [ -z ${CLAS12DIR+x} ];
   then
     if [ -z ${CLARA_HOME+x} ];
@@ -37,5 +33,6 @@ if [ -z ${CLAS12DIR+x} ];
     echo +-------------------------------------------------------------------------
     echo -en "${NC}";
 fi
+source $CLAS12DIR/bin/env.sh
 
 java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.service.eb.EBDebug $*

--- a/bin/eb-monitor
+++ b/bin/eb-monitor
@@ -1,18 +1,41 @@
-#!/bin/sh -f
+#!/bin/bash
 
-source `dirname $0`/env.sh 
+NC='\033[0m'              # No Color
+RED='\033[0;31m'          # Red
+GREEN='\033[0;32m'        # Green
+YELLOW='\033[0;33m'       # Yellow
+BLUE='\033[0;34m'         # Blue
+PURPLE='\033[0;35m'       # Purple
 
-#CLARA_HOME=`dirname $0`
-#CLARA_SERVICES=`dirname $0`
-#DATAMINING=`dirname $0`
+export MALLOC_ARENA_MAX=1
+export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
+export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
 
-echo +-------------------------------------------------------------------------
-echo "| Starting CLARA-PLATFORM with CLARA_SERVICES = " $CLARA_SERVICES
-echo +-------------------------------------------------------------------------
-echo "\n"
+if [ -z ${CLAS12DIR+x} ];
+  then
+    if [ -z ${CLARA_HOME+x} ];
+      then
+        echo -en "${RED}";
+        echo "Error: CLAS12DIR and CLARA_HOME not set.";
+        echo "Set one of these to continue";
+        echo "Exiting";
+        echo -en "${NC}";
+        exit 1;
+      else
+        export CLARA_SERVICES=$CLARA_HOME/lib;
+        export CLAS12DIR=$CLARA_HOME/plugins/clas12;
+        echo -en "${GREEN}";
+        echo +-------------------------------------------------------------------------
+        echo "| Using CLARA_SERVICES to set CLAS12DIR: $CLAS12DIR";
+        echo +-------------------------------------------------------------------------
+        echo -en "${NC}";
+    fi
+  else
+    echo -en "${GREEN}";
+    echo +-------------------------------------------------------------------------
+    echo "| Using CLAS12DIR, manually set to: $CLAS12DIR";
+    echo +-------------------------------------------------------------------------
+    echo -en "${NC}";
+fi
 
-echo "INSTALLATION DIRECTORY = " $CLARA_HOME
-echo "LIBRARY DIRECTORY      = " $DATAMINING/lib/clas/
-
-#java -cp "$DATAMINING/lib/clas/core/*" org.jlab.coda.eventViewer.EventTreeFrame $*
-java -Xms1024m -cp "$DATAMINING/lib/clas/*:$DATAMINING/lib/services/*:$DATAMINING/lib/utils/*" org.jlab.service.eb.EBDebug $*
+java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.service.eb.EBDebug $*

--- a/bin/ec-monitor
+++ b/bin/ec-monitor
@@ -7,10 +7,6 @@ YELLOW='\033[0;33m'       # Yellow
 BLUE='\033[0;34m'         # Blue
 PURPLE='\033[0;35m'       # Purple
 
-export MALLOC_ARENA_MAX=1
-export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
-export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
-
 if [ -z ${CLAS12DIR+x} ];
   then
     if [ -z ${CLARA_HOME+x} ];
@@ -37,5 +33,6 @@ if [ -z ${CLAS12DIR+x} ];
     echo +-------------------------------------------------------------------------
     echo -en "${NC}";
 fi
+source $CLAS12DIR/bin/env.sh
 
 java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.display.ec.ECMonitor $*

--- a/bin/ec-monitor
+++ b/bin/ec-monitor
@@ -1,18 +1,41 @@
-#!/bin/sh -f
+#!/bin/bash
 
-source `dirname $0`/env.sh 
+NC='\033[0m'              # No Color
+RED='\033[0;31m'          # Red
+GREEN='\033[0;32m'        # Green
+YELLOW='\033[0;33m'       # Yellow
+BLUE='\033[0;34m'         # Blue
+PURPLE='\033[0;35m'       # Purple
 
-#CLARA_HOME=`dirname $0`
-#CLARA_SERVICES=`dirname $0`
-#DATAMINING=`dirname $0`
+export MALLOC_ARENA_MAX=1
+export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
+export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
 
-echo +-------------------------------------------------------------------------
-echo "| Starting CLARA-PLATFORM with CLARA_SERVICES = " $CLARA_SERVICES
-echo +-------------------------------------------------------------------------
-echo "\n"
+if [ -z ${CLAS12DIR+x} ];
+  then
+    if [ -z ${CLARA_HOME+x} ];
+      then
+        echo -en "${RED}";
+        echo "Error: CLAS12DIR and CLARA_HOME not set.";
+        echo "Set one of these to continue";
+        echo "Exiting";
+        echo -en "${NC}";
+        exit 1;
+      else
+        export CLARA_SERVICES=$CLARA_HOME/lib;
+        export CLAS12DIR=$CLARA_HOME/plugins/clas12;
+        echo -en "${GREEN}";
+        echo +-------------------------------------------------------------------------
+        echo "| Using CLARA_SERVICES to set CLAS12DIR: $CLAS12DIR";
+        echo +-------------------------------------------------------------------------
+        echo -en "${NC}";
+    fi
+  else
+    echo -en "${GREEN}";
+    echo +-------------------------------------------------------------------------
+    echo "| Using CLAS12DIR, manually set to: $CLAS12DIR";
+    echo +-------------------------------------------------------------------------
+    echo -en "${NC}";
+fi
 
-echo "INSTALLATION DIRECTORY = " $CLARA_HOME
-echo "LIBRARY DIRECTORY      = " $DATAMINING/lib/clas/
-
-#java -cp "$DATAMINING/lib/clas/core/*" org.jlab.coda.eventViewer.EventTreeFrame $*
-java -Xms1024m -cp "$DATAMINING/lib/clas/*:$DATAMINING/lib/services/*:$DATAMINING/lib/utils/*" org.jlab.display.ec.ECMonitor $*
+java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.display.ec.ECMonitor $*

--- a/bin/env.sh
+++ b/bin/env.sh
@@ -1,10 +1,6 @@
 #!/bin/bash
 
-SCRIPT_DIR=`dirname $0`
-DISTRO_DIR=$SCRIPT_DIR/../ ; export DISTRO_DIR
-CLAS12DIR=$SCRIPT_DIR/../ ; export CLAS12DIR
-CLARA_SERVICES=$DISTRO_DIR/lib/services; export CLARA_SERVICES
-DATAMINING=$DISTRO_DIR ; export DATAMINING
-TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat ; export TORUSMAP
-SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat ; export SOLENOIDMAP
+export MALLOC_ARENA_MAX=1
+export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
+export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
 

--- a/bin/evio-viewer
+++ b/bin/evio-viewer
@@ -1,19 +1,41 @@
-#!/bin/sh -f
+#!/bin/bash
 
-source `dirname $0`/env.sh 
+NC='\033[0m'              # No Color
+RED='\033[0;31m'          # Red
+GREEN='\033[0;32m'        # Green
+YELLOW='\033[0;33m'       # Yellow
+BLUE='\033[0;34m'         # Blue
+PURPLE='\033[0;35m'       # Purple
 
-#CLARA_HOME=`dirname $0`
-#CLARA_SERVICES=`dirname $0`
-#DATAMINING=`dirname $0`
+export MALLOC_ARENA_MAX=1
+export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
+export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
 
-echo +-------------------------------------------------------------------------
-echo "| Starting CLARA-PLATFORM with CLARA_SERVICES = " $CLARA_SERVICES
-echo +-------------------------------------------------------------------------
-echo "\n"
+if [ -z ${CLAS12DIR+x} ];
+  then
+    if [ -z ${CLARA_HOME+x} ];
+      then
+        echo -en "${RED}";
+        echo "Error: CLAS12DIR and CLARA_HOME not set.";
+        echo "Set one of these to continue";
+        echo "Exiting";
+        echo -en "${NC}";
+        exit 1;
+      else
+        export CLARA_SERVICES=$CLARA_HOME/lib;
+        export CLAS12DIR=$CLARA_HOME/plugins/clas12;
+        echo -en "${GREEN}";
+        echo +-------------------------------------------------------------------------
+        echo "| Using CLARA_SERVICES to set CLAS12DIR: $CLAS12DIR";
+        echo +-------------------------------------------------------------------------
+        echo -en "${NC}";
+    fi
+  else
+    echo -en "${GREEN}";
+    echo +-------------------------------------------------------------------------
+    echo "| Using CLAS12DIR, manually set to: $CLAS12DIR";
+    echo +-------------------------------------------------------------------------
+    echo -en "${NC}";
+fi
 
-echo "INSTALLATION DIRECTORY = " $CLARA_HOME
-echo "LIBRARY DIRECTORY      = " $DATAMINING/lib/clas/
-
-java -cp "$DATAMINING/lib/clas/*" org.jlab.coda.eventViewer.EventTreeFrame $*
-#java -cp "$DATAMINING/lib/clas/*" org.jlab.coda.jevio.graphics.EventTreeFrame $*
-#java -cp "$DATAMINING/lib/clas/*" org.jlab.coda.jevio.graphics.EventTreeFrame $*
+java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.coda.eventViewer.EventTreeFrame $*

--- a/bin/evio-viewer
+++ b/bin/evio-viewer
@@ -7,10 +7,6 @@ YELLOW='\033[0;33m'       # Yellow
 BLUE='\033[0;34m'         # Blue
 PURPLE='\033[0;35m'       # Purple
 
-export MALLOC_ARENA_MAX=1
-export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
-export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
-
 if [ -z ${CLAS12DIR+x} ];
   then
     if [ -z ${CLARA_HOME+x} ];
@@ -37,5 +33,6 @@ if [ -z ${CLAS12DIR+x} ];
     echo +-------------------------------------------------------------------------
     echo -en "${NC}";
 fi
+source $CLAS12DIR/bin/env.sh
 
 java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.coda.eventViewer.EventTreeFrame $*

--- a/bin/evio2hipo
+++ b/bin/evio2hipo
@@ -1,21 +1,41 @@
 #!/bin/bash
 
-source `dirname $0`/env.sh 
+NC='\033[0m'              # No Color
+RED='\033[0;31m'          # Red
+GREEN='\033[0;32m'        # Green
+YELLOW='\033[0;33m'       # Yellow
+BLUE='\033[0;34m'         # Blue
+PURPLE='\033[0;35m'       # Purple
 
-MALLOC_ARENA_MAX=1; export MALLOC_ARENA_MAX
+export MALLOC_ARENA_MAX=1
+export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
+export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
 
-#CLARA_HOME=`dirname $0`
-#CLARA_SERVICES=`dirname $0`
-#DATAMINING=`dirname $0`
+if [ -z ${CLAS12DIR+x} ];
+  then
+    if [ -z ${CLARA_HOME+x} ];
+      then
+        echo -en "${RED}";
+        echo "Error: CLAS12DIR and CLARA_HOME not set.";
+        echo "Set one of these to continue";
+        echo "Exiting";
+        echo -en "${NC}";
+        exit 1;
+      else
+        export CLARA_SERVICES=$CLARA_HOME/lib;
+        export CLAS12DIR=$CLARA_HOME/plugins/clas12;
+        echo -en "${GREEN}";
+        echo +-------------------------------------------------------------------------
+        echo "| Using CLARA_SERVICES to set CLAS12DIR: $CLAS12DIR";
+        echo +-------------------------------------------------------------------------
+        echo -en "${NC}";
+    fi
+  else
+    echo -en "${GREEN}";
+    echo +-------------------------------------------------------------------------
+    echo "| Using CLAS12DIR, manually set to: $CLAS12DIR";
+    echo +-------------------------------------------------------------------------
+    echo -en "${NC}";
+fi
 
-echo +-------------------------------------------------------------------------
-echo "| Starting CLARA-PLATFORM with CLARA_SERVICES = " $CLARA_SERVICES
-echo +-------------------------------------------------------------------------
-echo "\n"
-
-echo "INSTALLATION DIRECTORY = " $CLARA_HOME
-echo "LIBRARY DIRECTORY      = " $DATAMINING/lib/clas/
-
-#java -cp "$DATAMINING/lib/clas/core/*" org.jlab.coda.eventViewer.EventTreeFrame $*
-#java -Xms1024m -cp "$DATAMINING/lib/clas/*:$DATAMINING/lib/plugins/*" org.jlab.io.hipo.HipoDataSync $*
-java -Xmx1536m -Xms1024m -cp "$DATAMINING/lib/clas/*:$DATAMINING/lib/plugins/*" org.jlab.clas.reco.io.EvioHipoEvent $*
+java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.clas.reco.io.EvioHipoEvent $*

--- a/bin/evio2hipo
+++ b/bin/evio2hipo
@@ -7,10 +7,6 @@ YELLOW='\033[0;33m'       # Yellow
 BLUE='\033[0;34m'         # Blue
 PURPLE='\033[0;35m'       # Purple
 
-export MALLOC_ARENA_MAX=1
-export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
-export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
-
 if [ -z ${CLAS12DIR+x} ];
   then
     if [ -z ${CLARA_HOME+x} ];
@@ -37,5 +33,7 @@ if [ -z ${CLAS12DIR+x} ];
     echo +-------------------------------------------------------------------------
     echo -en "${NC}";
 fi
+source $CLAS12DIR/bin/env.sh
+
 
 java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.clas.reco.io.EvioHipoEvent $*

--- a/bin/eviocure
+++ b/bin/eviocure
@@ -1,21 +1,41 @@
-#!/bin/sh -f
+#!/bin/bash
 
-source `dirname $0`/env.sh 
+NC='\033[0m'              # No Color
+RED='\033[0;31m'          # Red
+GREEN='\033[0;32m'        # Green
+YELLOW='\033[0;33m'       # Yellow
+BLUE='\033[0;34m'         # Blue
+PURPLE='\033[0;35m'       # Purple
 
-MALLOC_ARENA_MAX=1; export MALLOC_ARENA_MAX
+export MALLOC_ARENA_MAX=1
+export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
+export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
 
-#CLARA_HOME=`dirname $0`
-#CLARA_SERVICES=`dirname $0`
-#DATAMINING=`dirname $0`
+if [ -z ${CLAS12DIR+x} ];
+  then
+    if [ -z ${CLARA_HOME+x} ];
+      then
+        echo -en "${RED}";
+        echo "Error: CLAS12DIR and CLARA_HOME not set.";
+        echo "Set one of these to continue";
+        echo "Exiting";
+        echo -en "${NC}";
+        exit 1;
+      else
+        export CLARA_SERVICES=$CLARA_HOME/lib;
+        export CLAS12DIR=$CLARA_HOME/plugins/clas12;
+        echo -en "${GREEN}";
+        echo +-------------------------------------------------------------------------
+        echo "| Using CLARA_SERVICES to set CLAS12DIR: $CLAS12DIR";
+        echo +-------------------------------------------------------------------------
+        echo -en "${NC}";
+    fi
+  else
+    echo -en "${GREEN}";
+    echo +-------------------------------------------------------------------------
+    echo "| Using CLAS12DIR, manually set to: $CLAS12DIR";
+    echo +-------------------------------------------------------------------------
+    echo -en "${NC}";
+fi
 
-echo +-------------------------------------------------------------------------
-echo "| Starting CLARA-PLATFORM with CLARA_SERVICES = " $CLARA_SERVICES
-echo +-------------------------------------------------------------------------
-echo "\n"
-
-echo "INSTALLATION DIRECTORY = " $CLARA_HOME
-echo "LIBRARY DIRECTORY      = " $DATAMINING/lib/clas/
-
-#java -cp "$DATAMINING/lib/clas/core/*" org.jlab.coda.eventViewer.EventTreeFrame $*
-#java -Xms1024m -cp "$DATAMINING/lib/clas/*:$DATAMINING/lib/plugins/*" org.jlab.io.hipo.HipoDataSync $*
-java -Xmx1536m -Xms1024m -cp "$DATAMINING/lib/clas/*:$DATAMINING/lib/plugins/*" org.jlab.io.utils.EvioCure $*
+java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.io.utils.EvioCure $*

--- a/bin/eviocure
+++ b/bin/eviocure
@@ -7,10 +7,6 @@ YELLOW='\033[0;33m'       # Yellow
 BLUE='\033[0;34m'         # Blue
 PURPLE='\033[0;35m'       # Purple
 
-export MALLOC_ARENA_MAX=1
-export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
-export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
-
 if [ -z ${CLAS12DIR+x} ];
   then
     if [ -z ${CLARA_HOME+x} ];
@@ -37,5 +33,6 @@ if [ -z ${CLAS12DIR+x} ];
     echo +-------------------------------------------------------------------------
     echo -en "${NC}";
 fi
+source $CLAS12DIR/bin/env.sh
 
 java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.io.utils.EvioCure $*

--- a/bin/eviodump
+++ b/bin/eviodump
@@ -7,10 +7,6 @@ YELLOW='\033[0;33m'       # Yellow
 BLUE='\033[0;34m'         # Blue
 PURPLE='\033[0;35m'       # Purple
 
-export MALLOC_ARENA_MAX=1
-export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
-export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
-
 if [ -z ${CLAS12DIR+x} ];
   then
     if [ -z ${CLARA_HOME+x} ];
@@ -37,5 +33,6 @@ if [ -z ${CLAS12DIR+x} ];
     echo +-------------------------------------------------------------------------
     echo -en "${NC}";
 fi
+source $CLAS12DIR/bin/env.sh
 
 java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.io.utils.DataSourceDump $*

--- a/bin/eviodump
+++ b/bin/eviodump
@@ -1,18 +1,41 @@
-#!/bin/sh -f
+#!/bin/bash
 
-source `dirname $0`/env.sh 
+NC='\033[0m'              # No Color
+RED='\033[0;31m'          # Red
+GREEN='\033[0;32m'        # Green
+YELLOW='\033[0;33m'       # Yellow
+BLUE='\033[0;34m'         # Blue
+PURPLE='\033[0;35m'       # Purple
 
-#CLARA_HOME=`dirname $0`
-#CLARA_SERVICES=`dirname $0`
-#DATAMINING=`dirname $0`
+export MALLOC_ARENA_MAX=1
+export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
+export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
 
-echo +-------------------------------------------------------------------------
-echo "| Starting CLARA-PLATFORM with CLARA_SERVICES = " $CLARA_SERVICES
-echo +-------------------------------------------------------------------------
-echo "\n"
+if [ -z ${CLAS12DIR+x} ];
+  then
+    if [ -z ${CLARA_HOME+x} ];
+      then
+        echo -en "${RED}";
+        echo "Error: CLAS12DIR and CLARA_HOME not set.";
+        echo "Set one of these to continue";
+        echo "Exiting";
+        echo -en "${NC}";
+        exit 1;
+      else
+        export CLARA_SERVICES=$CLARA_HOME/lib;
+        export CLAS12DIR=$CLARA_HOME/plugins/clas12;
+        echo -en "${GREEN}";
+        echo +-------------------------------------------------------------------------
+        echo "| Using CLARA_SERVICES to set CLAS12DIR: $CLAS12DIR";
+        echo +-------------------------------------------------------------------------
+        echo -en "${NC}";
+    fi
+  else
+    echo -en "${GREEN}";
+    echo +-------------------------------------------------------------------------
+    echo "| Using CLAS12DIR, manually set to: $CLAS12DIR";
+    echo +-------------------------------------------------------------------------
+    echo -en "${NC}";
+fi
 
-echo "INSTALLATION DIRECTORY = " $CLARA_HOME
-echo "LIBRARY DIRECTORY      = " $DATAMINING/lib/clas/
-
-#java -cp "$DATAMINING/lib/clas/core/*" org.jlab.coda.eventViewer.EventTreeFrame $*
-java -Xms1024m -cp "$DATAMINING/lib/clas/*:$DATAMINING/lib/plugins/*" org.jlab.io.utils.DataSourceDump $*
+java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.io.utils.DataSourceDump $*

--- a/bin/gemc-evio
+++ b/bin/gemc-evio
@@ -1,18 +1,41 @@
-#!/bin/sh -f
+#!/bin/bash
 
-source `dirname $0`/env.sh 
+NC='\033[0m'              # No Color
+RED='\033[0;31m'          # Red
+GREEN='\033[0;32m'        # Green
+YELLOW='\033[0;33m'       # Yellow
+BLUE='\033[0;34m'         # Blue
+PURPLE='\033[0;35m'       # Purple
 
-#CLARA_HOME=`dirname $0`
-#CLARA_SERVICES=`dirname $0`
-#DATAMINING=`dirname $0`
+export MALLOC_ARENA_MAX=1
+export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
+export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
 
-echo +-------------------------------------------------------------------------
-echo "| Starting CLARA-PLATFORM with CLARA_SERVICES = " $CLARA_SERVICES
-echo +-------------------------------------------------------------------------
-echo "\n"
+if [ -z ${CLAS12DIR+x} ];
+  then
+    if [ -z ${CLARA_HOME+x} ];
+      then
+        echo -en "${RED}";
+        echo "Error: CLAS12DIR and CLARA_HOME not set.";
+        echo "Set one of these to continue";
+        echo "Exiting";
+        echo -en "${NC}";
+        exit 1;
+      else
+        export CLARA_SERVICES=$CLARA_HOME/lib;
+        export CLAS12DIR=$CLARA_HOME/plugins/clas12;
+        echo -en "${GREEN}";
+        echo +-------------------------------------------------------------------------
+        echo "| Using CLARA_SERVICES to set CLAS12DIR: $CLAS12DIR";
+        echo +-------------------------------------------------------------------------
+        echo -en "${NC}";
+    fi
+  else
+    echo -en "${GREEN}";
+    echo +-------------------------------------------------------------------------
+    echo "| Using CLAS12DIR, manually set to: $CLAS12DIR";
+    echo +-------------------------------------------------------------------------
+    echo -en "${NC}";
+fi
 
-echo "INSTALLATION DIRECTORY = " $CLARA_HOME
-echo "LIBRARY DIRECTORY      = " $DATAMINING/lib/clas/
-
-#java -cp "$DATAMINING/lib/clas/core/*" org.jlab.coda.eventViewer.EventTreeFrame $*
-java -Xms1024m -cp "$DATAMINING/lib/clas/*:$DATAMINING/lib/plugins/*" org.jlab.clas.reco.io.ReconstructionIO $*
+java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.clas.reco.io.ReconstructionIO $*

--- a/bin/gemc-evio
+++ b/bin/gemc-evio
@@ -7,10 +7,6 @@ YELLOW='\033[0;33m'       # Yellow
 BLUE='\033[0;34m'         # Blue
 PURPLE='\033[0;35m'       # Purple
 
-export MALLOC_ARENA_MAX=1
-export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
-export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
-
 if [ -z ${CLAS12DIR+x} ];
   then
     if [ -z ${CLARA_HOME+x} ];
@@ -37,5 +33,6 @@ if [ -z ${CLAS12DIR+x} ];
     echo +-------------------------------------------------------------------------
     echo -en "${NC}";
 fi
+source $CLAS12DIR/bin/env.sh
 
 java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.clas.reco.io.ReconstructionIO $*

--- a/bin/grid
+++ b/bin/grid
@@ -7,10 +7,6 @@ YELLOW='\033[0;33m'       # Yellow
 BLUE='\033[0;34m'         # Blue
 PURPLE='\033[0;35m'       # Purple
 
-export MALLOC_ARENA_MAX=1
-export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
-export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
-
 if [ -z ${CLAS12DIR+x} ];
   then
     if [ -z ${CLARA_HOME+x} ];
@@ -37,5 +33,6 @@ if [ -z ${CLAS12DIR+x} ];
     echo +-------------------------------------------------------------------------
     echo -en "${NC}";
 fi
+source $CLAS12DIR/bin/env.sh
 
 java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.groot.matrix.SparseGridIO $*

--- a/bin/grid
+++ b/bin/grid
@@ -1,18 +1,41 @@
-#!/bin/sh -f
+#!/bin/bash
 
-source `dirname $0`/env.sh 
+NC='\033[0m'              # No Color
+RED='\033[0;31m'          # Red
+GREEN='\033[0;32m'        # Green
+YELLOW='\033[0;33m'       # Yellow
+BLUE='\033[0;34m'         # Blue
+PURPLE='\033[0;35m'       # Purple
 
-#CLARA_HOME=`dirname $0`
-#CLARA_SERVICES=`dirname $0`
-#DATAMINING=`dirname $0`
+export MALLOC_ARENA_MAX=1
+export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
+export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
 
-echo +-------------------------------------------------------------------------
-echo "| Starting CLARA-PLATFORM with CLARA_SERVICES = " $CLARA_SERVICES
-echo +-------------------------------------------------------------------------
-echo "\n"
+if [ -z ${CLAS12DIR+x} ];
+  then
+    if [ -z ${CLARA_HOME+x} ];
+      then
+        echo -en "${RED}";
+        echo "Error: CLAS12DIR and CLARA_HOME not set.";
+        echo "Set one of these to continue";
+        echo "Exiting";
+        echo -en "${NC}";
+        exit 1;
+      else
+        export CLARA_SERVICES=$CLARA_HOME/lib;
+        export CLAS12DIR=$CLARA_HOME/plugins/clas12;
+        echo -en "${GREEN}";
+        echo +-------------------------------------------------------------------------
+        echo "| Using CLARA_SERVICES to set CLAS12DIR: $CLAS12DIR";
+        echo +-------------------------------------------------------------------------
+        echo -en "${NC}";
+    fi
+  else
+    echo -en "${GREEN}";
+    echo +-------------------------------------------------------------------------
+    echo "| Using CLAS12DIR, manually set to: $CLAS12DIR";
+    echo +-------------------------------------------------------------------------
+    echo -en "${NC}";
+fi
 
-echo "INSTALLATION DIRECTORY = " $CLARA_HOME
-echo "LIBRARY DIRECTORY      = " $DATAMINING/lib/clas/
-
-#java -cp "$DATAMINING/lib/clas/core/*" org.jlab.coda.eventViewer.EventTreeFrame $*
-java -Xms1024m -cp "$DATAMINING/lib/clas/*:$DATAMINING/lib/plugins/*" org.jlab.groot.matrix.SparseGridIO $*
+java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.groot.matrix.SparseGridIO $*

--- a/bin/hadd
+++ b/bin/hadd
@@ -7,10 +7,6 @@ YELLOW='\033[0;33m'       # Yellow
 BLUE='\033[0;34m'         # Blue
 PURPLE='\033[0;35m'       # Purple
 
-export MALLOC_ARENA_MAX=1
-export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
-export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
-
 if [ -z ${CLAS12DIR+x} ];
   then
     if [ -z ${CLARA_HOME+x} ];
@@ -37,5 +33,6 @@ if [ -z ${CLAS12DIR+x} ];
     echo +-------------------------------------------------------------------------
     echo -en "${NC}";
 fi
+source $CLAS12DIR/bin/env.sh
 
 java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.groot.data.TDirectory $*

--- a/bin/hadd
+++ b/bin/hadd
@@ -1,18 +1,41 @@
-#!/bin/sh -f
+#!/bin/bash
 
-source `dirname $0`/env.sh 
+NC='\033[0m'              # No Color
+RED='\033[0;31m'          # Red
+GREEN='\033[0;32m'        # Green
+YELLOW='\033[0;33m'       # Yellow
+BLUE='\033[0;34m'         # Blue
+PURPLE='\033[0;35m'       # Purple
 
-#CLARA_HOME=`dirname $0`
-#CLARA_SERVICES=`dirname $0`
-#DATAMINING=`dirname $0`
+export MALLOC_ARENA_MAX=1
+export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
+export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
 
-echo +-------------------------------------------------------------------------
-echo "| Starting CLARA-PLATFORM with CLARA_SERVICES = " $CLARA_SERVICES
-echo +-------------------------------------------------------------------------
-echo "\n"
+if [ -z ${CLAS12DIR+x} ];
+  then
+    if [ -z ${CLARA_HOME+x} ];
+      then
+        echo -en "${RED}";
+        echo "Error: CLAS12DIR and CLARA_HOME not set.";
+        echo "Set one of these to continue";
+        echo "Exiting";
+        echo -en "${NC}";
+        exit 1;
+      else
+        export CLARA_SERVICES=$CLARA_HOME/lib;
+        export CLAS12DIR=$CLARA_HOME/plugins/clas12;
+        echo -en "${GREEN}";
+        echo +-------------------------------------------------------------------------
+        echo "| Using CLARA_SERVICES to set CLAS12DIR: $CLAS12DIR";
+        echo +-------------------------------------------------------------------------
+        echo -en "${NC}";
+    fi
+  else
+    echo -en "${GREEN}";
+    echo +-------------------------------------------------------------------------
+    echo "| Using CLAS12DIR, manually set to: $CLAS12DIR";
+    echo +-------------------------------------------------------------------------
+    echo -en "${NC}";
+fi
 
-echo "INSTALLATION DIRECTORY = " $CLARA_HOME
-echo "LIBRARY DIRECTORY      = " $DATAMINING/lib/clas/
-
-#java -cp "$DATAMINING/lib/clas/core/*" org.jlab.coda.eventViewer.EventTreeFrame $*
-java -Xms1024m -cp "$DATAMINING/lib/clas/*:$DATAMINING/lib/plugins/*" org.jlab.groot.data.TDirectory $*
+java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.groot.data.TDirectory $*

--- a/bin/hipo-utils
+++ b/bin/hipo-utils
@@ -7,10 +7,6 @@ YELLOW='\033[0;33m'       # Yellow
 BLUE='\033[0;34m'         # Blue
 PURPLE='\033[0;35m'       # Purple
 
-export MALLOC_ARENA_MAX=1
-export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
-export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
-
 if [ -z ${CLAS12DIR+x} ];
   then
     if [ -z ${CLARA_HOME+x} ];
@@ -37,5 +33,6 @@ if [ -z ${CLAS12DIR+x} ];
     echo +-------------------------------------------------------------------------
     echo -en "${NC}";
 fi
+source $CLAS12DIR/bin/env.sh
 
 java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.jnp.hipo.utils.HipoUtilities $*

--- a/bin/hipo-utils
+++ b/bin/hipo-utils
@@ -1,22 +1,41 @@
-#!/bin/sh -f
+#!/bin/bash
 
-source `dirname $0`/env.sh 
+NC='\033[0m'              # No Color
+RED='\033[0;31m'          # Red
+GREEN='\033[0;32m'        # Green
+YELLOW='\033[0;33m'       # Yellow
+BLUE='\033[0;34m'         # Blue
+PURPLE='\033[0;35m'       # Purple
 
-MALLOC_ARENA_MAX=1; export MALLOC_ARENA_MAX
+export MALLOC_ARENA_MAX=1
+export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
+export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
 
-#CLARA_HOME=`dirname $0`
-#CLARA_SERVICES=`dirname $0`
-#DATAMINING=`dirname $0`
+if [ -z ${CLAS12DIR+x} ];
+  then
+    if [ -z ${CLARA_HOME+x} ];
+      then
+        echo -en "${RED}";
+        echo "Error: CLAS12DIR and CLARA_HOME not set.";
+        echo "Set one of these to continue";
+        echo "Exiting";
+        echo -en "${NC}";
+        exit 1;
+      else
+        export CLARA_SERVICES=$CLARA_HOME/lib;
+        export CLAS12DIR=$CLARA_HOME/plugins/clas12;
+        echo -en "${GREEN}";
+        echo +-------------------------------------------------------------------------
+        echo "| Using CLARA_SERVICES to set CLAS12DIR: $CLAS12DIR";
+        echo +-------------------------------------------------------------------------
+        echo -en "${NC}";
+    fi
+  else
+    echo -en "${GREEN}";
+    echo +-------------------------------------------------------------------------
+    echo "| Using CLAS12DIR, manually set to: $CLAS12DIR";
+    echo +-------------------------------------------------------------------------
+    echo -en "${NC}";
+fi
 
-echo +-------------------------------------------------------------------------
-echo "| Starting CLARA-PLATFORM with CLARA_SERVICES = " $CLARA_SERVICES
-echo +-------------------------------------------------------------------------
-echo "\n"
-
-echo "INSTALLATION DIRECTORY = " $CLARA_HOME
-echo "LIBRARY DIRECTORY      = " $DATAMINING/lib/clas/
-
-#java -cp "$DATAMINING/lib/clas/core/*" org.jlab.coda.eventViewer.EventTreeFrame $*
-#java -Xms1024m -cp "$DATAMINING/lib/clas/*:$DATAMINING/lib/plugins/*" org.jlab.io.hipo.HipoDataSync $*
-#java -Xms1024m -cp "$DATAMINING/lib/clas/*:$DATAMINING/lib/plugins/*" org.jlab.clas.reco.io.HipoFileUtils $*
-java -Xmx2048m -Xms1024m -cp "$DATAMINING/lib/clas/*:$DATAMINING/lib/plugins/*" org.jlab.jnp.hipo.utils.HipoUtilities $*
+java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.jnp.hipo.utils.HipoUtilities $*

--- a/bin/hipo-writer
+++ b/bin/hipo-writer
@@ -7,10 +7,6 @@ YELLOW='\033[0;33m'       # Yellow
 BLUE='\033[0;34m'         # Blue
 PURPLE='\033[0;35m'       # Purple
 
-export MALLOC_ARENA_MAX=1
-export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
-export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
-
 if [ -z ${CLAS12DIR+x} ];
   then
     if [ -z ${CLARA_HOME+x} ];
@@ -37,5 +33,6 @@ if [ -z ${CLAS12DIR+x} ];
     echo +-------------------------------------------------------------------------
     echo -en "${NC}";
 fi
+source $CLAS12DIR/bin/env.sh
 
 java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.io.utils.Evio2HipoConverter $*

--- a/bin/hipo-writer
+++ b/bin/hipo-writer
@@ -1,19 +1,41 @@
-#!/bin/sh -f
+#!/bin/bash
 
-source `dirname $0`/env.sh 
+NC='\033[0m'              # No Color
+RED='\033[0;31m'          # Red
+GREEN='\033[0;32m'        # Green
+YELLOW='\033[0;33m'       # Yellow
+BLUE='\033[0;34m'         # Blue
+PURPLE='\033[0;35m'       # Purple
 
-#CLARA_HOME=`dirname $0`
-#CLARA_SERVICES=`dirname $0`
-#DATAMINING=`dirname $0`
+export MALLOC_ARENA_MAX=1
+export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
+export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
 
-echo +-------------------------------------------------------------------------
-echo "| Starting CLARA-PLATFORM with CLARA_SERVICES = " $CLARA_SERVICES
-echo +-------------------------------------------------------------------------
-echo "\n"
+if [ -z ${CLAS12DIR+x} ];
+  then
+    if [ -z ${CLARA_HOME+x} ];
+      then
+        echo -en "${RED}";
+        echo "Error: CLAS12DIR and CLARA_HOME not set.";
+        echo "Set one of these to continue";
+        echo "Exiting";
+        echo -en "${NC}";
+        exit 1;
+      else
+        export CLARA_SERVICES=$CLARA_HOME/lib;
+        export CLAS12DIR=$CLARA_HOME/plugins/clas12;
+        echo -en "${GREEN}";
+        echo +-------------------------------------------------------------------------
+        echo "| Using CLARA_SERVICES to set CLAS12DIR: $CLAS12DIR";
+        echo +-------------------------------------------------------------------------
+        echo -en "${NC}";
+    fi
+  else
+    echo -en "${GREEN}";
+    echo +-------------------------------------------------------------------------
+    echo "| Using CLAS12DIR, manually set to: $CLAS12DIR";
+    echo +-------------------------------------------------------------------------
+    echo -en "${NC}";
+fi
 
-echo "INSTALLATION DIRECTORY = " $CLARA_HOME
-echo "LIBRARY DIRECTORY      = " $DATAMINING/lib/clas/
-
-#java -cp "$DATAMINING/lib/clas/core/*" org.jlab.coda.eventViewer.EventTreeFrame $*
-#java -Xms1024m -cp "$DATAMINING/lib/clas/*:$DATAMINING/lib/plugins/*" org.jlab.io.hipo.HipoDataSync $*
-java -Xms1024m -cp "$DATAMINING/lib/clas/*:$DATAMINING/lib/plugins/*" org.jlab.io.utils.Evio2HipoConverter $*
+java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.io.utils.Evio2HipoConverter $*

--- a/bin/kpp-plots
+++ b/bin/kpp-plots
@@ -7,10 +7,6 @@ YELLOW='\033[0;33m'       # Yellow
 BLUE='\033[0;34m'         # Blue
 PURPLE='\033[0;35m'       # Purple
 
-export MALLOC_ARENA_MAX=1
-export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
-export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
-
 if [ -z ${CLAS12DIR+x} ];
   then
     if [ -z ${CLARA_HOME+x} ];
@@ -37,5 +33,6 @@ if [ -z ${CLAS12DIR+x} ];
     echo +-------------------------------------------------------------------------
     echo -en "${NC}";
 fi
+source $CLAS12DIR/bin/env.sh
 
 java -Dsun.java2d.pmoffscreen=false -Xmx2048m -Xms1024m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.clas.viewer.KPPViewer $*

--- a/bin/kpp-plots
+++ b/bin/kpp-plots
@@ -1,19 +1,41 @@
-#!/bin/sh -f
+#!/bin/bash
 
-source `dirname $0`/env.sh 
+NC='\033[0m'              # No Color
+RED='\033[0;31m'          # Red
+GREEN='\033[0;32m'        # Green
+YELLOW='\033[0;33m'       # Yellow
+BLUE='\033[0;34m'         # Blue
+PURPLE='\033[0;35m'       # Purple
 
-#CLARA_HOME=`dirname $0`
-#CLARA_SERVICES=`dirname $0`
-#DATAMINING=`dirname $0`
+export MALLOC_ARENA_MAX=1
+export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
+export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
 
-echo +-------------------------------------------------------------------------
-echo "| Starting CLARA-PLATFORM with CLARA_SERVICES = " $CLARA_SERVICES
-echo +-------------------------------------------------------------------------
-echo "\n"
+if [ -z ${CLAS12DIR+x} ];
+  then
+    if [ -z ${CLARA_HOME+x} ];
+      then
+        echo -en "${RED}";
+        echo "Error: CLAS12DIR and CLARA_HOME not set.";
+        echo "Set one of these to continue";
+        echo "Exiting";
+        echo -en "${NC}";
+        exit 1;
+      else
+        export CLARA_SERVICES=$CLARA_HOME/lib;
+        export CLAS12DIR=$CLARA_HOME/plugins/clas12;
+        echo -en "${GREEN}";
+        echo +-------------------------------------------------------------------------
+        echo "| Using CLARA_SERVICES to set CLAS12DIR: $CLAS12DIR";
+        echo +-------------------------------------------------------------------------
+        echo -en "${NC}";
+    fi
+  else
+    echo -en "${GREEN}";
+    echo +-------------------------------------------------------------------------
+    echo "| Using CLAS12DIR, manually set to: $CLAS12DIR";
+    echo +-------------------------------------------------------------------------
+    echo -en "${NC}";
+fi
 
-echo "INSTALLATION DIRECTORY = " $CLARA_HOME
-echo "LIBRARY DIRECTORY      = " $DATAMINING/lib/clas/
-
-#java -cp "$DATAMINING/lib/clas/core/*" org.jlab.coda.eventViewer.EventTreeFrame $*
-#java -Xms1024m -cp "$DATAMINING/lib/clas/*:$DATAMINING/lib/plugins/*" org.jlab.io.hipo.HipoDataSync $*
-java -Dsun.java2d.pmoffscreen=false -Xmx2048m -Xms1024m -cp "$DATAMINING/lib/clas/*:$DATAMINING/lib/utils/*:$DATAMINING/lib/services/*" org.clas.viewer.KPPViewer $*
+java -Dsun.java2d.pmoffscreen=false -Xmx2048m -Xms1024m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.clas.viewer.KPPViewer $*

--- a/bin/notsouseful-util
+++ b/bin/notsouseful-util
@@ -7,6 +7,10 @@ YELLOW='\033[0;33m'       # Yellow
 BLUE='\033[0;34m'         # Blue
 PURPLE='\033[0;35m'       # Purple
 
+export MALLOC_ARENA_MAX=1
+export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
+export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
+
 if [ -z ${CLAS12DIR+x} ];
   then
     if [ -z ${CLARA_HOME+x} ];
@@ -33,6 +37,5 @@ if [ -z ${CLAS12DIR+x} ];
     echo +-------------------------------------------------------------------------
     echo -en "${NC}";
 fi
-source $CLAS12DIR/bin/env.sh
 
-java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.clas.reco.EngineProcessor $*
+java -Xmx1024m -Xms256m -cp "$CLAS12DIR/../validation/lib/*:$CLAS12DIR/lib/utils/*:$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.clas.reco.EngineProcessor $*

--- a/bin/notsouseful-util
+++ b/bin/notsouseful-util
@@ -1,20 +1,41 @@
 #!/bin/bash
 
-source `dirname $0`/env.sh 
+NC='\033[0m'              # No Color
+RED='\033[0;31m'          # Red
+GREEN='\033[0;32m'        # Green
+YELLOW='\033[0;33m'       # Yellow
+BLUE='\033[0;34m'         # Blue
+PURPLE='\033[0;35m'       # Purple
 
-MALLOC_ARENA_MAX=1; export MALLOC_ARENA_MAX
-#CLARA_HOME=`dirname $0`
-#CLARA_SERVICES=`dirname $0`
-#DATAMINING=`dirname $0`
+export MALLOC_ARENA_MAX=1
+export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
+export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
 
-echo +-------------------------------------------------------------------------
-echo "| Starting CLARA-PLATFORM with CLARA_SERVICES = " $CLARA_SERVICES
-echo +-------------------------------------------------------------------------
-echo "\n"
+if [ -z ${CLAS12DIR+x} ];
+  then
+    if [ -z ${CLARA_HOME+x} ];
+      then
+        echo -en "${RED}";
+        echo "Error: CLAS12DIR and CLARA_HOME not set.";
+        echo "Set one of these to continue";
+        echo "Exiting";
+        echo -en "${NC}";
+        exit 1;
+      else
+        export CLARA_SERVICES=$CLARA_HOME/lib;
+        export CLAS12DIR=$CLARA_HOME/plugins/clas12;
+        echo -en "${GREEN}";
+        echo +-------------------------------------------------------------------------
+        echo "| Using CLARA_SERVICES to set CLAS12DIR: $CLAS12DIR";
+        echo +-------------------------------------------------------------------------
+        echo -en "${NC}";
+    fi
+  else
+    echo -en "${GREEN}";
+    echo +-------------------------------------------------------------------------
+    echo "| Using CLAS12DIR, manually set to: $CLAS12DIR";
+    echo +-------------------------------------------------------------------------
+    echo -en "${NC}";
+fi
 
-echo "INSTALLATION DIRECTORY = " $CLARA_HOME
-echo "LIBRARY DIRECTORY      = " $DATAMINING/lib/clas/
-
-#java -cp "$DATAMINING/lib/clas/core/*" org.jlab.coda.eventViewer.EventTreeFrame $*
-#java -Xms1024m -cp "$DATAMINING/lib/clas/*:$DATAMINING/lib/plugins/*" org.jlab.io.hipo.HipoDataSync $*
-java -Xmx1536m -Xms1024m -cp "$DATAMINING/lib/clas/*:$DATAMINING/lib/services/*:$DATAMINING/lib/utils/*" org.jlab.clas.reco.EngineProcessor $*
+java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.clas.reco.EngineProcessor $*

--- a/bin/notsouseful-util
+++ b/bin/notsouseful-util
@@ -7,10 +7,6 @@ YELLOW='\033[0;33m'       # Yellow
 BLUE='\033[0;34m'         # Blue
 PURPLE='\033[0;35m'       # Purple
 
-export MALLOC_ARENA_MAX=1
-export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
-export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
-
 if [ -z ${CLAS12DIR+x} ];
   then
     if [ -z ${CLARA_HOME+x} ];
@@ -37,5 +33,6 @@ if [ -z ${CLAS12DIR+x} ];
     echo +-------------------------------------------------------------------------
     echo -en "${NC}";
 fi
+source $CLAS12DIR/bin/env.sh
 
 java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.clas.reco.EngineProcessor $*

--- a/bin/pion
+++ b/bin/pion
@@ -1,19 +1,41 @@
-#!/bin/sh -f
+#!/bin/bash
 
-source `dirname $0`/env.sh 
+NC='\033[0m'              # No Color
+RED='\033[0;31m'          # Red
+GREEN='\033[0;32m'        # Green
+YELLOW='\033[0;33m'       # Yellow
+BLUE='\033[0;34m'         # Blue
+PURPLE='\033[0;35m'       # Purple
 
-#CLARA_HOME=`dirname $0`
-#CLARA_SERVICES=`dirname $0`
-#DATAMINING=`dirname $0`
+export MALLOC_ARENA_MAX=1
+export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
+export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
 
-echo +-------------------------------------------------------------------------
-echo "| Starting CLARA-PLATFORM with CLARA_SERVICES = " $CLARA_SERVICES
-echo +-------------------------------------------------------------------------
-echo "\n"
+if [ -z ${CLAS12DIR+x} ];
+  then
+    if [ -z ${CLARA_HOME+x} ];
+      then
+        echo -en "${RED}";
+        echo "Error: CLAS12DIR and CLARA_HOME not set.";
+        echo "Set one of these to continue";
+        echo "Exiting";
+        echo -en "${NC}";
+        exit 1;
+      else
+        export CLARA_SERVICES=$CLARA_HOME/lib;
+        export CLAS12DIR=$CLARA_HOME/plugins/clas12;
+        echo -en "${GREEN}";
+        echo +-------------------------------------------------------------------------
+        echo "| Using CLARA_SERVICES to set CLAS12DIR: $CLAS12DIR";
+        echo +-------------------------------------------------------------------------
+        echo -en "${NC}";
+    fi
+  else
+    echo -en "${GREEN}";
+    echo +-------------------------------------------------------------------------
+    echo "| Using CLAS12DIR, manually set to: $CLAS12DIR";
+    echo +-------------------------------------------------------------------------
+    echo -en "${NC}";
+fi
 
-echo "INSTALLATION DIRECTORY = " $CLARA_HOME
-echo "LIBRARY DIRECTORY      = " $DATAMINING/lib/clas/
-
-#java -cp "$DATAMINING/lib/clas/core/*" org.jlab.coda.eventViewer.EventTreeFrame $*
-#java -Xms1024m -cp "$DATAMINING/lib/clas/*:$DATAMINING/lib/plugins/*" org.jlab.io.hipo.HipoDataSync $*
-java -Xms1024m -cp "$DATAMINING/lib/clas/*:$DATAMINING/lib/services/*" org.jlab.display.ec.ECPionFinder $*
+java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.display.ec.ECPionFinder $*

--- a/bin/pion
+++ b/bin/pion
@@ -7,10 +7,6 @@ YELLOW='\033[0;33m'       # Yellow
 BLUE='\033[0;34m'         # Blue
 PURPLE='\033[0;35m'       # Purple
 
-export MALLOC_ARENA_MAX=1
-export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
-export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
-
 if [ -z ${CLAS12DIR+x} ];
   then
     if [ -z ${CLARA_HOME+x} ];
@@ -37,5 +33,6 @@ if [ -z ${CLAS12DIR+x} ];
     echo +-------------------------------------------------------------------------
     echo -en "${NC}";
 fi
+source $CLAS12DIR/bin/env.sh
 
 java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.display.ec.ECPionFinder $*

--- a/bin/rec-monitor
+++ b/bin/rec-monitor
@@ -7,10 +7,6 @@ YELLOW='\033[0;33m'       # Yellow
 BLUE='\033[0;34m'         # Blue
 PURPLE='\033[0;35m'       # Purple
 
-export MALLOC_ARENA_MAX=1
-export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
-export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
-
 if [ -z ${CLAS12DIR+x} ];
   then
     if [ -z ${CLARA_HOME+x} ];
@@ -37,5 +33,6 @@ if [ -z ${CLAS12DIR+x} ];
     echo +-------------------------------------------------------------------------
     echo -en "${NC}";
 fi
+source $CLAS12DIR/bin/env.sh
 
 java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.monitor.eb.ReconstructionMonitor $*

--- a/bin/rec-monitor
+++ b/bin/rec-monitor
@@ -1,18 +1,41 @@
-#!/bin/sh -f
+#!/bin/bash
 
-source `dirname $0`/env.sh 
+NC='\033[0m'              # No Color
+RED='\033[0;31m'          # Red
+GREEN='\033[0;32m'        # Green
+YELLOW='\033[0;33m'       # Yellow
+BLUE='\033[0;34m'         # Blue
+PURPLE='\033[0;35m'       # Purple
 
-#CLARA_HOME=`dirname $0`
-#CLARA_SERVICES=`dirname $0`
-#DATAMINING=`dirname $0`
+export MALLOC_ARENA_MAX=1
+export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
+export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
 
-echo +-------------------------------------------------------------------------
-echo "| Starting CLARA-PLATFORM with CLARA_SERVICES = " $CLARA_SERVICES
-echo +-------------------------------------------------------------------------
-echo "\n"
+if [ -z ${CLAS12DIR+x} ];
+  then
+    if [ -z ${CLARA_HOME+x} ];
+      then
+        echo -en "${RED}";
+        echo "Error: CLAS12DIR and CLARA_HOME not set.";
+        echo "Set one of these to continue";
+        echo "Exiting";
+        echo -en "${NC}";
+        exit 1;
+      else
+        export CLARA_SERVICES=$CLARA_HOME/lib;
+        export CLAS12DIR=$CLARA_HOME/plugins/clas12;
+        echo -en "${GREEN}";
+        echo +-------------------------------------------------------------------------
+        echo "| Using CLARA_SERVICES to set CLAS12DIR: $CLAS12DIR";
+        echo +-------------------------------------------------------------------------
+        echo -en "${NC}";
+    fi
+  else
+    echo -en "${GREEN}";
+    echo +-------------------------------------------------------------------------
+    echo "| Using CLAS12DIR, manually set to: $CLAS12DIR";
+    echo +-------------------------------------------------------------------------
+    echo -en "${NC}";
+fi
 
-echo "INSTALLATION DIRECTORY = " $CLARA_HOME
-echo "LIBRARY DIRECTORY      = " $DATAMINING/lib/clas/
-
-#java -cp "$DATAMINING/lib/clas/core/*" org.jlab.coda.eventViewer.EventTreeFrame $*
-java -Xms1024m -cp "$DATAMINING/lib/clas/*:$DATAMINING/lib/plugins/*" org.jlab.monitor.eb.ReconstructionMonitor $*
+java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.monitor.eb.ReconstructionMonitor $*

--- a/bin/run-groovy
+++ b/bin/run-groovy
@@ -1,5 +1,4 @@
 #!/bin/bash
-#!/bin/bash
 
 NC='\033[0m'              # No Color
 RED='\033[0;31m'          # Red
@@ -7,10 +6,6 @@ GREEN='\033[0;32m'        # Green
 YELLOW='\033[0;33m'       # Yellow
 BLUE='\033[0;34m'         # Blue
 PURPLE='\033[0;35m'       # Purple
-
-export MALLOC_ARENA_MAX=1
-export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
-export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
 
 if [ -z ${CLAS12DIR+x} ];
   then
@@ -38,6 +33,7 @@ if [ -z ${CLAS12DIR+x} ];
     echo +-------------------------------------------------------------------------
     echo -en "${NC}";
 fi
+source $CLAS12DIR/bin/env.sh
 
 #--------------------------------------------------------------
 # Adding supporting COAT jar files

--- a/bin/run-groovy
+++ b/bin/run-groovy
@@ -1,60 +1,66 @@
 #!/bin/bash
+#!/bin/bash
 
-source `dirname $0`/env.sh 
+NC='\033[0m'              # No Color
+RED='\033[0;31m'          # Red
+GREEN='\033[0;32m'        # Green
+YELLOW='\033[0;33m'       # Yellow
+BLUE='\033[0;34m'         # Blue
+PURPLE='\033[0;35m'       # Purple
 
-CLARA_HOME=`dirname $0`/..
-DATAMINING=`dirname $0`/..
-CLAS12DIR=`dirname $0`/.. ; export CLAS12DIR
- 
-CLARA_SERVICES=$CLAS12DIR/lib/services ; export CLARA_SERVICES
+export MALLOC_ARENA_MAX=1
+export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
+export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
 
-#JYTHONPATH=${DATAMINING}/lib/jython
-#echo ${JYTHONPATH}
+if [ -z ${CLAS12DIR+x} ];
+  then
+    if [ -z ${CLARA_HOME+x} ];
+      then
+        echo -en "${RED}";
+        echo "Error: CLAS12DIR and CLARA_HOME not set.";
+        echo "Set one of these to continue";
+        echo "Exiting";
+        echo -en "${NC}";
+        exit 1;
+      else
+        export CLARA_SERVICES=$CLARA_HOME/lib;
+        export CLAS12DIR=$CLARA_HOME/plugins/clas12;
+        echo -en "${GREEN}";
+        echo +-------------------------------------------------------------------------
+        echo "| Using CLARA_SERVICES to set CLAS12DIR: $CLAS12DIR";
+        echo +-------------------------------------------------------------------------
+        echo -en "${NC}";
+    fi
+  else
+    echo -en "${GREEN}";
+    echo +-------------------------------------------------------------------------
+    echo "| Using CLAS12DIR, manually set to: $CLAS12DIR";
+    echo +-------------------------------------------------------------------------
+    echo -en "${NC}";
+fi
 
 #--------------------------------------------------------------
 # Adding supporting COAT jar files
-for i in `ls -a $DATAMINING/lib/clas/*.jar`
-do  
-#echo "$i"
-if [ -z "${JYPATH}" ] ; then
-JYPATH="$i"
-else
-JYPATH=${JYPATH}:"$i"
-fi
-done 
-#--------------------------------------------------------------
-# Adding supporting plugins directory
-for i in `ls -a $DATAMINING/lib/services/*.jar`
-do
-if [ -z "${JYPATH}" ] ; then
-JYPATH="$i"
-else
-JYPATH=${JYPATH}:"$i"
-fi
+for i in $(ls -a $CLAS12DIR/lib/*/*.jar)
+  do
+    if [[ $i = *"coat-libs"* ]]; then
+      VER=$(echo $i | cut -d'-' -f3)
+      DATE=$(stat --format="%z" $i | cut -d' ' -f1)
+    fi
+
+    if [ -z "${JYPATH+x}" ] ; then
+      JYPATH="$i"
+    else
+      JYPATH=${JYPATH}:"$i"
+    fi
 done
-#--------------------------------------------------------------
-# Adding supporting plugins directory
-#--------------------------------------------------------------
-# Done loading plugins
-#--------------------------------------------------------------
-# Adding supporting plugins directory 
-for i in `ls -a $DATAMINING/lib/utils/*.jar`
-do
-if [ -z "${JYPATH}" ] ; then
-JYPATH="$i"
-else
-JYPATH=${JYPATH}:"$i"
-fi
-done
-#-------------------------------------------------------------
-JYPATH=${JYPATH}:${DATAMINING}/lib/packages
-echo " "
-echo " "
-echo "*****************************************"
-echo "*    Running COAT-JAVA Groovy Scripts   *"
-echo "*    Version : 3a  Release : 2016       *" 
-echo "*****************************************"
-echo " "
-echo " "
-JAVA_OPTS="-Dsun.java2d.pmoffscreen=false -Xms1024m -Xmx2048m"; export JAVA_OPTS
+
+echo -en "${BLUE}";
+echo "*************************************************"
+echo -e "*\tRunning COAT-JAVA Groovy Scripts\t*"
+echo -e "*\tVersion : ${VER}  Release : ${DATE} \t*"
+echo "*************************************************"
+echo -en "${NC}";
+
+export JAVA_OPTS="-Dsun.java2d.pmoffscreen=false -Xms1024m -Xmx2048m";
 groovy -cp "$JYPATH" $*

--- a/bin/studio
+++ b/bin/studio
@@ -1,18 +1,41 @@
-#!/bin/sh -f
+#!/bin/bash
 
-source `dirname $0`/env.sh 
+NC='\033[0m'              # No Color
+RED='\033[0;31m'          # Red
+GREEN='\033[0;32m'        # Green
+YELLOW='\033[0;33m'       # Yellow
+BLUE='\033[0;34m'         # Blue
+PURPLE='\033[0;35m'       # Purple
 
-#CLARA_HOME=`dirname $0`
-#CLARA_SERVICES=`dirname $0`
-#DATAMINING=`dirname $0`
+export MALLOC_ARENA_MAX=1
+export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
+export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
 
-echo +-------------------------------------------------------------------------
-echo "| Starting CLARA-PLATFORM with CLARA_SERVICES = " $CLARA_SERVICES
-echo +-------------------------------------------------------------------------
-echo "\n"
+if [ -z ${CLAS12DIR+x} ];
+  then
+    if [ -z ${CLARA_HOME+x} ];
+      then
+        echo -en "${RED}";
+        echo "Error: CLAS12DIR and CLARA_HOME not set.";
+        echo "Set one of these to continue";
+        echo "Exiting";
+        echo -en "${NC}";
+        exit 1;
+      else
+        export CLARA_SERVICES=$CLARA_HOME/lib;
+        export CLAS12DIR=$CLARA_HOME/plugins/clas12;
+        echo -en "${GREEN}";
+        echo +-------------------------------------------------------------------------
+        echo "| Using CLARA_SERVICES to set CLAS12DIR: $CLAS12DIR";
+        echo +-------------------------------------------------------------------------
+        echo -en "${NC}";
+    fi
+  else
+    echo -en "${GREEN}";
+    echo +-------------------------------------------------------------------------
+    echo "| Using CLAS12DIR, manually set to: $CLAS12DIR";
+    echo +-------------------------------------------------------------------------
+    echo -en "${NC}";
+fi
 
-echo "INSTALLATION DIRECTORY = " $CLARA_HOME
-echo "LIBRARY DIRECTORY      = " $DATAMINING/lib/clas/
-
-#java -cp "$DATAMINING/lib/clas/core/*" org.jlab.coda.eventViewer.EventTreeFrame $*
-java -Xms1024m -Xmx2048m -cp "$DATAMINING/lib/clas/*:$DATAMINING/lib/plugins/*" org.jlab.clas.physics.EventTree $*
+java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.clas.physics.EventTree $*

--- a/bin/studio
+++ b/bin/studio
@@ -7,10 +7,6 @@ YELLOW='\033[0;33m'       # Yellow
 BLUE='\033[0;34m'         # Blue
 PURPLE='\033[0;35m'       # Purple
 
-export MALLOC_ARENA_MAX=1
-export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
-export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
-
 if [ -z ${CLAS12DIR+x} ];
   then
     if [ -z ${CLARA_HOME+x} ];
@@ -37,5 +33,6 @@ if [ -z ${CLAS12DIR+x} ];
     echo +-------------------------------------------------------------------------
     echo -en "${NC}";
 fi
+source $CLAS12DIR/bin/env.sh
 
 java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.clas.physics.EventTree $*

--- a/bin/update
+++ b/bin/update
@@ -7,10 +7,6 @@ YELLOW='\033[0;33m'       # Yellow
 BLUE='\033[0;34m'         # Blue
 PURPLE='\033[0;35m'       # Purple
 
-export MALLOC_ARENA_MAX=1
-export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
-export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
-
 if [ -z ${CLAS12DIR+x} ];
   then
     if [ -z ${CLARA_HOME+x} ];
@@ -37,6 +33,7 @@ if [ -z ${CLAS12DIR+x} ];
     echo +-------------------------------------------------------------------------
     echo -en "${NC}";
 fi
+source $CLAS12DIR/bin/env.sh
 
 java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.clas.update.UpdateManager link http://clasweb.jlab.org/clas12maven/org/jlab/coat/coat-libs/3.0-SNAPSHOT/ coat-libs-3.0-SNAPSHOT.jar $CLAS12DIR/lib/clas
 

--- a/bin/update
+++ b/bin/update
@@ -1,22 +1,45 @@
-#!/bin/sh -f
+#!/bin/bash
 
-source `dirname $0`/env.sh 
+NC='\033[0m'              # No Color
+RED='\033[0;31m'          # Red
+GREEN='\033[0;32m'        # Green
+YELLOW='\033[0;33m'       # Yellow
+BLUE='\033[0;34m'         # Blue
+PURPLE='\033[0;35m'       # Purple
 
-#CLARA_HOME=`dirname $0`
-#CLARA_SERVICES=`dirname $0`
-#DATAMINING=`dirname $0`
-#echo +-------------------------------------------------------------------------
-#echo "| Starting CLARA-PLATFORM with CLARA_SERVICES = " $CLARA_SERVICES
-#echo +-------------------------------------------------------------------------
-#echo "\n"
-#echo "INSTALLATION DIRECTORY = " $CLARA_HOME
-#echo "LIBRARY DIRECTORY      = " $DATAMINING/lib/clas/
-#java -cp "$DATAMINING/lib/clas/core/*" org.jlab.coda.eventViewer.EventTreeFrame $*
-#java -cp "$DATAMINING/lib/clas/*:$DATAMINING/lib/plugins/*" org.jlab.clas.tools.utils.StringTable
-#java -cp "$DATAMINING/lib/clas/*:$DATAMINING/lib/utils/*:$DATAMINING/lib/plugins/*" org.jlab.clas.update.UpdateManager $*
+export MALLOC_ARENA_MAX=1
+export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
+export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
 
-java -cp "$DATAMINING/lib/clas/*:$DATAMINING/lib/utils/*:$DATAMINING/lib/plugins/*" org.jlab.clas.update.UpdateManager link http://clasweb.jlab.org/clas12maven/org/jlab/coat/coat-libs/3.0-SNAPSHOT/ coat-libs-3.0-SNAPSHOT.jar $CLAS12DIR/lib/clas
+if [ -z ${CLAS12DIR+x} ];
+  then
+    if [ -z ${CLARA_HOME+x} ];
+      then
+        echo -en "${RED}";
+        echo "Error: CLAS12DIR and CLARA_HOME not set.";
+        echo "Set one of these to continue";
+        echo "Exiting";
+        echo -en "${NC}";
+        exit 1;
+      else
+        export CLARA_SERVICES=$CLARA_HOME/lib;
+        export CLAS12DIR=$CLARA_HOME/plugins/clas12;
+        echo -en "${GREEN}";
+        echo +-------------------------------------------------------------------------
+        echo "| Using CLARA_SERVICES to set CLAS12DIR: $CLAS12DIR";
+        echo +-------------------------------------------------------------------------
+        echo -en "${NC}";
+    fi
+  else
+    echo -en "${GREEN}";
+    echo +-------------------------------------------------------------------------
+    echo "| Using CLAS12DIR, manually set to: $CLAS12DIR";
+    echo +-------------------------------------------------------------------------
+    echo -en "${NC}";
+fi
 
-java -cp "$DATAMINING/lib/clas/*:$DATAMINING/lib/utils/*:$DATAMINING/lib/plugins/*" org.jlab.clas.update.UpdateManager link https://userweb.jlab.org/~devita/kpp/ KPP-Plots-1.0.jar  $CLAS12DIR/lib/utils
+java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.clas.update.UpdateManager link http://clasweb.jlab.org/clas12maven/org/jlab/coat/coat-libs/3.0-SNAPSHOT/ coat-libs-3.0-SNAPSHOT.jar $CLAS12DIR/lib/clas
 
-java -cp "$DATAMINING/lib/clas/*:$DATAMINING/lib/utils/*:$DATAMINING/lib/plugins/*" org.jlab.clas.update.UpdateManager link https://userweb.jlab.org/~devita/kpp/ KPP-Monitoring-1.0.jar  $CLAS12DIR/lib/utils
+java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.clas.update.UpdateManager link https://userweb.jlab.org/~devita/kpp/ KPP-Plots-1.0.jar  $CLAS12DIR/lib/utils
+
+java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.clas.update.UpdateManager link https://userweb.jlab.org/~devita/kpp/ KPP-Monitoring-1.0.jar  $CLAS12DIR/lib/utils

--- a/bin/x-client
+++ b/bin/x-client
@@ -7,10 +7,6 @@ YELLOW='\033[0;33m'       # Yellow
 BLUE='\033[0;34m'         # Blue
 PURPLE='\033[0;35m'       # Purple
 
-export MALLOC_ARENA_MAX=1
-export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
-export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
-
 if [ -z ${CLAS12DIR+x} ];
   then
     if [ -z ${CLARA_HOME+x} ];
@@ -37,5 +33,6 @@ if [ -z ${CLAS12DIR+x} ];
     echo +-------------------------------------------------------------------------
     echo -en "${NC}";
 fi
+source $CLAS12DIR/bin/env.sh
 
 java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.io.hipo.HipoRingSource $*

--- a/bin/x-client
+++ b/bin/x-client
@@ -1,17 +1,41 @@
-#!/bin/sh -f
+#!/bin/bash
 
-source `dirname $0`/env.sh 
+NC='\033[0m'              # No Color
+RED='\033[0;31m'          # Red
+GREEN='\033[0;32m'        # Green
+YELLOW='\033[0;33m'       # Yellow
+BLUE='\033[0;34m'         # Blue
+PURPLE='\033[0;35m'       # Purple
 
-#CLARA_HOME=`dirname $0`
-#CLARA_SERVICES=`dirname $0`
-#DATAMINING=`dirname $0`
+export MALLOC_ARENA_MAX=1
+export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
+export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
 
-echo +-------------------------------------------------------------------------
-echo "| Starting CLARA-PLATFORM with CLARA_SERVICES = " $CLARA_SERVICES
-echo +-------------------------------------------------------------------------
-echo "\n"
+if [ -z ${CLAS12DIR+x} ];
+  then
+    if [ -z ${CLARA_HOME+x} ];
+      then
+        echo -en "${RED}";
+        echo "Error: CLAS12DIR and CLARA_HOME not set.";
+        echo "Set one of these to continue";
+        echo "Exiting";
+        echo -en "${NC}";
+        exit 1;
+      else
+        export CLARA_SERVICES=$CLARA_HOME/lib;
+        export CLAS12DIR=$CLARA_HOME/plugins/clas12;
+        echo -en "${GREEN}";
+        echo +-------------------------------------------------------------------------
+        echo "| Using CLARA_SERVICES to set CLAS12DIR: $CLAS12DIR";
+        echo +-------------------------------------------------------------------------
+        echo -en "${NC}";
+    fi
+  else
+    echo -en "${GREEN}";
+    echo +-------------------------------------------------------------------------
+    echo "| Using CLAS12DIR, manually set to: $CLAS12DIR";
+    echo +-------------------------------------------------------------------------
+    echo -en "${NC}";
+fi
 
-echo "INSTALLATION DIRECTORY = " $CLARA_HOME
-echo "LIBRARY DIRECTORY      = " $DATAMINING/lib/clas/
-
-java -Xms1024m -cp "$DATAMINING/lib/clas/*:$DATAMINING/lib/plugins/*" org.jlab.io.hipo.HipoRingSource $*
+java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.io.hipo.HipoRingSource $*

--- a/bin/x-client-evio
+++ b/bin/x-client-evio
@@ -7,10 +7,6 @@ YELLOW='\033[0;33m'       # Yellow
 BLUE='\033[0;34m'         # Blue
 PURPLE='\033[0;35m'       # Purple
 
-export MALLOC_ARENA_MAX=1
-export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
-export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
-
 if [ -z ${CLAS12DIR+x} ];
   then
     if [ -z ${CLARA_HOME+x} ];
@@ -37,5 +33,6 @@ if [ -z ${CLAS12DIR+x} ];
     echo +-------------------------------------------------------------------------
     echo -en "${NC}";
 fi
+source $CLAS12DIR/bin/env.sh
 
 java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.io.evio.EvioRingSource $*

--- a/bin/x-client-evio
+++ b/bin/x-client-evio
@@ -1,17 +1,41 @@
-#!/bin/sh -f
+#!/bin/bash
 
-source `dirname $0`/env.sh 
+NC='\033[0m'              # No Color
+RED='\033[0;31m'          # Red
+GREEN='\033[0;32m'        # Green
+YELLOW='\033[0;33m'       # Yellow
+BLUE='\033[0;34m'         # Blue
+PURPLE='\033[0;35m'       # Purple
 
-#CLARA_HOME=`dirname $0`
-#CLARA_SERVICES=`dirname $0`
-#DATAMINING=`dirname $0`
+export MALLOC_ARENA_MAX=1
+export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
+export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
 
-echo +-------------------------------------------------------------------------
-echo "| Starting CLARA-PLATFORM with CLARA_SERVICES = " $CLARA_SERVICES
-echo +-------------------------------------------------------------------------
-echo "\n"
+if [ -z ${CLAS12DIR+x} ];
+  then
+    if [ -z ${CLARA_HOME+x} ];
+      then
+        echo -en "${RED}";
+        echo "Error: CLAS12DIR and CLARA_HOME not set.";
+        echo "Set one of these to continue";
+        echo "Exiting";
+        echo -en "${NC}";
+        exit 1;
+      else
+        export CLARA_SERVICES=$CLARA_HOME/lib;
+        export CLAS12DIR=$CLARA_HOME/plugins/clas12;
+        echo -en "${GREEN}";
+        echo +-------------------------------------------------------------------------
+        echo "| Using CLARA_SERVICES to set CLAS12DIR: $CLAS12DIR";
+        echo +-------------------------------------------------------------------------
+        echo -en "${NC}";
+    fi
+  else
+    echo -en "${GREEN}";
+    echo +-------------------------------------------------------------------------
+    echo "| Using CLAS12DIR, manually set to: $CLAS12DIR";
+    echo +-------------------------------------------------------------------------
+    echo -en "${NC}";
+fi
 
-echo "INSTALLATION DIRECTORY = " $CLARA_HOME
-echo "LIBRARY DIRECTORY      = " $DATAMINING/lib/clas/
-
-java -Xms1024m -cp "$DATAMINING/lib/clas/*:$DATAMINING/lib/plugins/*" org.jlab.io.evio.EvioRingSource $*
+java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.io.evio.EvioRingSource $*

--- a/bin/x-server
+++ b/bin/x-server
@@ -7,10 +7,6 @@ YELLOW='\033[0;33m'       # Yellow
 BLUE='\033[0;34m'         # Blue
 PURPLE='\033[0;35m'       # Purple
 
-export MALLOC_ARENA_MAX=1
-export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
-export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
-
 if [ -z ${CLAS12DIR+x} ];
   then
     if [ -z ${CLARA_HOME+x} ];
@@ -37,5 +33,6 @@ if [ -z ${CLAS12DIR+x} ];
     echo +-------------------------------------------------------------------------
     echo -en "${NC}";
 fi
+source $CLAS12DIR/bin/env.sh
 
 java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.clas.service.DataDistributionService $*

--- a/bin/x-server
+++ b/bin/x-server
@@ -1,21 +1,41 @@
-#!/bin/sh -f
+#!/bin/bash
 
-source `dirname $0`/env.sh 
+NC='\033[0m'              # No Color
+RED='\033[0;31m'          # Red
+GREEN='\033[0;32m'        # Green
+YELLOW='\033[0;33m'       # Yellow
+BLUE='\033[0;34m'         # Blue
+PURPLE='\033[0;35m'       # Purple
 
-#CLARA_HOME=`dirname $0`
-#CLARA_SERVICES=`dirname $0`
-#DATAMINING=`dirname $0`
+export MALLOC_ARENA_MAX=1
+export TORUSMAP=Symm_torus_r2501_phi16_z251_24Apr2018.dat
+export SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
 
-echo +-------------------------------------------------------------------------
-echo "| Starting CLARA-PLATFORM with CLARA_SERVICES = " $CLARA_SERVICES
-echo +-------------------------------------------------------------------------
-echo "\n"
+if [ -z ${CLAS12DIR+x} ];
+  then
+    if [ -z ${CLARA_HOME+x} ];
+      then
+        echo -en "${RED}";
+        echo "Error: CLAS12DIR and CLARA_HOME not set.";
+        echo "Set one of these to continue";
+        echo "Exiting";
+        echo -en "${NC}";
+        exit 1;
+      else
+        export CLARA_SERVICES=$CLARA_HOME/lib;
+        export CLAS12DIR=$CLARA_HOME/plugins/clas12;
+        echo -en "${GREEN}";
+        echo +-------------------------------------------------------------------------
+        echo "| Using CLARA_SERVICES to set CLAS12DIR: $CLAS12DIR";
+        echo +-------------------------------------------------------------------------
+        echo -en "${NC}";
+    fi
+  else
+    echo -en "${GREEN}";
+    echo +-------------------------------------------------------------------------
+    echo "| Using CLAS12DIR, manually set to: $CLAS12DIR";
+    echo +-------------------------------------------------------------------------
+    echo -en "${NC}";
+fi
 
-echo "INSTALLATION DIRECTORY = " $CLARA_HOME
-echo "LIBRARY DIRECTORY      = " $DATAMINING/lib/clas/
-
-#java -cp "$DATAMINING/lib/clas/core/*" org.jlab.coda.eventViewer.EventTreeFrame $*
-#java -Xms1024m -cp "$DATAMINING/lib/clas/*:$DATAMINING/lib/plugins/*" org.jlab.io.hipo.HipoDataSync $*
-#java  -XX:+UseNUMA -XX:+UseBiasedLocking -cp "$DATAMINING/lib/clas/*:$DATAMINING/lib/plugins/*" org.jlab.coda.xmsg.sys.xMsgProxy &
-#java -cp "$DATAMINING/lib/clas/*:$DATAMINING/lib/plugins/*" org.jlab.coda.xmsg.sys.xMsgProxy
-java -Xms1024m -cp "$DATAMINING/lib/clas/*:$DATAMINING/lib/plugins/*" org.jlab.clas.service.DataDistributionService $*
+java -Xmx1024m -Xms256m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*" org.jlab.clas.service.DataDistributionService $*

--- a/validation/advanced-tests/run-eb-tests.sh
+++ b/validation/advanced-tests/run-eb-tests.sh
@@ -70,11 +70,10 @@ esac
 # set up environment
 if [ $useClara -eq 0 ]
 then
-    COAT=../../coatjava
-    source $COAT/bin/env.sh
+    COAT=$CLAS12DIR
 else
     CLARA_HOME=$PWD/clara_installation/
-    COAT=$CLARA_HOME/plugins/clas12/
+    COAT=$CLAS12DIR
     export CLARA_HOME
 fi
 
@@ -124,7 +123,7 @@ then
     # run reconstruction:
     if [ $useClara -eq 0 ]
     then
-        ../../coatjava/bin/notsouseful-util -i ${webFileStub}.hipo -o out_${webFileStub}.hipo -c 2
+        $COAT/bin/notsouseful-util -i ${webFileStub}.hipo -o out_${webFileStub}.hipo -c 2
     else
         echo "set inputDir $PWD/" > cook.clara
         echo "set outputDir $PWD/" >> cook.clara

--- a/validation/advanced-tests/run-eb-tests.sh
+++ b/validation/advanced-tests/run-eb-tests.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+export CLAS12DIR=/home/travis/build/JeffersonLab/clas12-offline-software/coatjava
+
 webDir=http://clasweb.jlab.org/clas12offline/distribution/coatjava/validation_files/eb
 webVersion=4a.2.3-fid-r10
 webDir=$webDir/$webVersion
@@ -77,12 +79,10 @@ else
     export CLARA_HOME
 fi
 
-classPath="$COAT/lib/services/*:$COAT/lib/clas/*:$COAT/lib/utils/*:../lib/*:src/"
-
-classPath2="../../coatjava/lib/services/*:../../coatjava/lib/clas/*:../../coatjava/lib/utils/*:../lib/*:src/"
+classPath="$COAT/lib/services/*:$COAT/lib/clas/*:$COAT/lib/utils/*:$COAT/../validation/lib/*:../lib/*:src/"
 
 # make sure test code compiles before anything else:
-javac -cp $classPath2 src/eb/EBTwoTrackTest.java
+javac -cp $classPath src/eb/EBTwoTrackTest.java
 if [ $? != 0 ] ; then echo "EBTwoTrackTest compilation failure" ; exit 1 ; fi
 
 # download and setup dependencies, run reconstruction:

--- a/validation/advanced-tests/run-eb-tests.sh
+++ b/validation/advanced-tests/run-eb-tests.sh
@@ -140,7 +140,7 @@ then
 fi
 
 # run Event Builder tests:
-java -DCLAS12DIR="$COAT" -Xmx1536m -Xms1024m -cp $classPath2 -DINPUTFILE=out_${webFileStub}.hipo org.junit.runner.JUnitCore eb.EBTwoTrackTest
+java -DCLAS12DIR="$COAT" -Xmx1536m -Xms1024m -cp $classPath -DINPUTFILE=out_${webFileStub}.hipo org.junit.runner.JUnitCore eb.EBTwoTrackTest
 if [ $? != 0 ] ; then echo "EBTwoTrackTest unit test failure" ; exit 1 ; else echo "EBTwoTrackTest passed unit tests" ; fi
 
 exit 0


### PR DESCRIPTION
The scripts use the environment variable CLAS12DIR to find the compiled classes. If CLAS12DIR is not defined it then falls back to using CLARA_HOME if it was installed as part of clara. This gets rid of assumptions about the filesystem structure in order to find the classes.