### PR TITLE
HTCC cluster updates

### DIFF
--- a/reconstruction/htcc/src/main/java/org/jlab/rec/htcc/HTCCCluster.java
+++ b/reconstruction/htcc/src/main/java/org/jlab/rec/htcc/HTCCCluster.java
@@ -151,8 +151,9 @@ class HTCCCluster {
         z = (float) rot.getZPrime();
 
         dtheta = Math.pow(dtheta, -0.5);
-        dphi = Math.pow(dphi, -0.5);
-
+    //    dphi = Math.pow(dphi, -0.5);
+        dphi = hitdphi.get(0);
+        dtheta = hitdtheta.get(0);
         nthetaclust = setitheta.size();
         nphiclust = setiphi.size();
     }

--- a/reconstruction/htcc/src/main/java/org/jlab/rec/htcc/HTCCReconstruction.java
+++ b/reconstruction/htcc/src/main/java/org/jlab/rec/htcc/HTCCReconstruction.java
@@ -350,9 +350,9 @@ public class HTCCReconstruction {
         double dtheta0[];
         double phi0;
         double dphi0;
-        int npeminclst;
+        double npeminclst;
         int npheminmax;
-        int npheminhit;
+        double npheminhit;
         int nhitmaxclst;
         int nthetamaxclst;
         int nphimaxclst;
@@ -371,15 +371,15 @@ public class HTCCReconstruction {
             }
             phi0 = Math.toRadians(15.0);
             dphi0 = Math.toRadians(15.0);
-            npeminclst = 1;
+            npeminclst = 0.1;
             npheminmax = 1;
-            npheminhit = 1;
+            npheminhit = 0.1;
             nhitmaxclst = 4;
             nthetamaxclst = 2;
             nphimaxclst = 2;
             //defaul value
             //maxtimediff = 2;
-            maxtimediff = 8;
+            maxtimediff = 12;
 
             t0 = new double[]{11.54, 11.93, 12.33, 12.75};
         }

--- a/reconstruction/htcc/src/main/java/org/jlab/rec/htcc/HTCCReconstruction.java
+++ b/reconstruction/htcc/src/main/java/org/jlab/rec/htcc/HTCCReconstruction.java
@@ -267,7 +267,7 @@ public class HTCCReconstruction {
                 double time = timeArray[testHit] - parameters.t0[ithetaTest];
                 double timeDiff = Math.abs(time - clusterTime);
 
-                double npheTest = npheArray[testHit];
+                double npheTest = npheArray[testHit]; 
                 // If the test hit is close enough in space and time
                 if ((ithetaDiff == 1 || iphiDiff == 1)
                         && (ithetaDiff + iphiDiff <= 2)
@@ -351,7 +351,7 @@ public class HTCCReconstruction {
         double phi0;
         double dphi0;
         double npeminclst;
-        int npheminmax;
+        double npheminmax;
         double npheminhit;
         int nhitmaxclst;
         int nthetamaxclst;
@@ -372,7 +372,7 @@ public class HTCCReconstruction {
             phi0 = Math.toRadians(15.0);
             dphi0 = Math.toRadians(15.0);
             npeminclst = 0.1;
-            npheminmax = 1;
+            npheminmax = 0.1;
             npheminhit = 0.1;
             nhitmaxclst = 4;
             nthetamaxclst = 2;


### PR DESCRIPTION
Three updates to HTCC clustering algorithm:
- cut on the minimal hit and cluster are reduced from 1 to 0.1;
- timing window to integrate clusters is increased to 12 ns;
- dphi and dtheta made the same for all hits (half of the mirror size).