### PR TITLE
commit -m "Revised cuts on unit tests." CVTReconstructionTest.java

### DIFF
--- a/reconstruction/cvt/src/test/java/org/jlab/rec/cvt/services/CVTReconstructionTest.java
+++ b/reconstruction/cvt/src/test/java/org/jlab/rec/cvt/services/CVTReconstructionTest.java
@@ -57,10 +57,10 @@ public class CVTReconstructionTest {
         assertEquals(testEvent.getBank("REC::Particle").rows(), 1);
         assertEquals(testEvent.getBank("REC::Particle").getByte("charge", 0), 1);
         testEvent.getBank("REC::Particle").show();
-        assertEquals(ClasMath.isWithinXPercent(10.0, testEvent.getBank("REC::Particle").getFloat("px", 0), 1.9504), true);
-        assertEquals(ClasMath.isWithinXPercent(10.0, testEvent.getBank("REC::Particle").getFloat("py", 0), 0.2741), true);
-        assertEquals(ClasMath.isWithinXPercent(10.0, testEvent.getBank("REC::Particle").getFloat("pz", 0), 0.3473), true);
-        assertEquals(ClasMath.isWithinXPercent(30.0, testEvent.getBank("REC::Particle").getFloat("vz", 0), -1.95444), true); 
+        assertEquals(ClasMath.isWithinXPercent(11.0, testEvent.getBank("REC::Particle").getFloat("px", 0), 1.876), true);
+        assertEquals(ClasMath.isWithinXPercent(15.0, testEvent.getBank("REC::Particle").getFloat("py", 0), 0.257), true);
+        assertEquals(ClasMath.isWithinXPercent(13.0, testEvent.getBank("REC::Particle").getFloat("pz", 0), 0.334), true);
+        assertEquals(ClasMath.isWithinXPercent(6.0, testEvent.getBank("REC::Particle").getFloat("vz", 0), -2.001), true); 
 
     }
     


### PR DESCRIPTION
Ranges for the unit test are 3 sigma from the centroid from current gemc simulation. Distributions for each unit test are shown below.

![pxunittest](https://user-images.githubusercontent.com/7873432/48992776-b3e51500-f107-11e8-91d4-64953afb9241.png)
![pyunittest](https://user-images.githubusercontent.com/7873432/48992779-b8113280-f107-11e8-80ce-72d7b94bc90f.png)
![pzunittest](https://user-images.githubusercontent.com/7873432/48992782-ba738c80-f107-11e8-934e-bd2cbd921119.png)
![vzunittest](https://user-images.githubusercontent.com/7873432/48992786-bd6e7d00-f107-11e8-8ad4-c1bab9f7dfd1.png)



