### PR TITLE
correct helicity for hwp, finalize helicity convention at -1/0/1 = -/UDF/+

### DIFF
--- a/common-tools/clas-reco/src/main/java/org/jlab/clas/detector/DetectorHeader.java
+++ b/common-tools/clas-reco/src/main/java/org/jlab/clas/detector/DetectorHeader.java
@@ -11,7 +11,7 @@ public class DetectorHeader {
     private long      trigger = 0;
     private double     rfTime = 0.0;
     private double  startTime = -1000.0;
-    private byte     helicity = -99;
+    private byte     helicity = 0;
     private float beamChargeGated = 0;
     private float    livetime = -1;
     private short eventCategory = 0;

--- a/reconstruction/eb/src/main/java/org/jlab/rec/eb/EBCCDBConstants.java
+++ b/reconstruction/eb/src/main/java/org/jlab/rec/eb/EBCCDBConstants.java
@@ -39,6 +39,7 @@ public class EBCCDBConstants {
     
     private static final String[] otherTableNames={
         "/runcontrol/fcup",
+        "/runcontrol/hwp",
         "/geometry/target",
         "/calibration/ftof/tres",
         //"/calibration/ctof/tres"
@@ -271,6 +272,7 @@ public class EBCCDBConstants {
         loadDouble(EBCCDBEnum.FCUP_slope,"/runcontrol/fcup","slope",0,0,0);
         loadDouble(EBCCDBEnum.FCUP_offset,"/runcontrol/fcup","offset",0,0,0);
         loadDouble(EBCCDBEnum.FCUP_atten,"/runcontrol/fcup","atten",0,0,0);
+        loadInteger(EBCCDBEnum.HWP_position,"/runcontrol/hwp","hwp",0,0,0);
 
         //loadDouble(EBCCDBEnum.HTCC_PION_THRESHOLD,
         //loadDouble(EBCCDBEnum.LTCC_PION_THRESHOLD,

--- a/reconstruction/eb/src/main/java/org/jlab/rec/eb/EBCCDBEnum.java
+++ b/reconstruction/eb/src/main/java/org/jlab/rec/eb/EBCCDBEnum.java
@@ -56,6 +56,7 @@ public enum EBCCDBEnum {
     LTCC_TimingRes,
     FCUP_slope,
     FCUP_offset,
-    FCUP_atten;
+    FCUP_atten,
+    HWP_position;
 }
 

--- a/reconstruction/eb/src/main/java/org/jlab/service/eb/EBio.java
+++ b/reconstruction/eb/src/main/java/org/jlab/service/eb/EBio.java
@@ -10,6 +10,7 @@ import org.jlab.io.evio.EvioFactory;
 import org.jlab.clas.detector.*;
 
 import org.jlab.rec.eb.EBScalers;
+import org.jlab.rec.eb.EBCCDBEnum;
 import org.jlab.rec.eb.EBCCDBConstants;
 
 /**
@@ -40,8 +41,10 @@ public class EBio {
             DataBank bank = event.getBank("HEL::adc");
             for (int ii=0; ii<bank.rows(); ii++) {
                 if (bank.getInt("component",ii)==helComponent) {
-                    byte helicity=0;
+                    byte helicity=-1;
                     if (bank.getInt("ped",ii)>helHalf) helicity=1;
+                    // correct for HWP position:
+                    helicity *= ccdb.getInteger(EBCCDBEnum.HWP_position);
                     dHeader.setHelicity(helicity);
                     break;
                 }


### PR DESCRIPTION
Uses CCDB's /runcontrol/hwp, https://clasweb.jlab.org/cgi-bin/ccdb/versions?table=/runcontrol/hwp

CCDB values are up to date by Harut for RG-A and RG-K and simulation.

Addresses issue #227 