### PR TITLE
[WIP] Added cmake example for configuring script and installing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.10)
+project(jacketjava
+  VERSION 0.0.1
+  DESCRIPTION "clas12 software"
+  )
+
+set(CLAS12_INSTALL_DIR ${CMAKE_INSTALL_PREFIX})
+
+configure_file( bin/hipo-utils.in  bin/hipo-utils @ONLY)
+
+install(DIRECTORY coatjava/
+  DESTINATION ${CMAKE_INSTALL_PREFIX}
+  )
+
+install(FILES bin/hipo-utils
+  DESTINATION bin)
+

--- a/bin/hipo-utils.in
+++ b/bin/hipo-utils.in
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+echo "INSTALLATION DIRECTORY = " @CLAS12_INSTALL_DIR@
+
+java -Xmx2048m -Xms1024m \
+  -cp "@CLAS12_INSTALL_DIR@/lib/clas/*:@CLAS12_INSTALL_DIR@/lib/plugins/*" \
+  org.jlab.jnp.hipo.utils.HipoUtilities $*
+


### PR DESCRIPTION
Added cmake example for configuring script and installing in a location that will be part of the users
environment (default is /usr/local).

bin/hipo-utils.in is configured by cmake based on where the base system will be
installed. Currently it assumes that the maven build has been already executed,
but in the future this could included as a step in the cmake build process.

To build and install in $HOME, try:
```
mkdir build && cd build
cmake ../. -DCMAKE_INSTALL_PREFIX=$HOME
make install
```

new file:   CMakeLists.txt
new file:   bin/hipo-utils.in