### PR TITLE
Updates to TDC-FADC time matching

### DIFF
--- a/reconstruction/ec/src/main/java/org/jlab/service/ec/ECCommon.java
+++ b/reconstruction/ec/src/main/java/org/jlab/service/ec/ECCommon.java
@@ -159,11 +159,13 @@ public class ECCommon {
 		IndexedTable       tmf = manager.getConstants(run, "/calibration/ec/tmf_offset"); 
 		IndexedTable       fgo = manager.getConstants(run, "/calibration/ec/fadc_global_offset");
 		IndexedTable       gtw = manager.getConstants(run, "/calibration/ec/global_time_walk");
+		IndexedTable    tmfcut = manager.getConstants(run,  "/calibration/ec/tmf_window");
         
         double PERIOD  = jitter.getDoubleValue("period",0,0,0);
         int    PHASE   = jitter.getIntValue("phase",0,0,0); 
         int    CYCLES  = jitter.getIntValue("cycles",0,0,0);        
         float FTOFFSET = (float) fgo.getDoubleValue("global_offset",0,0,0); //global shift of trigger time
+        float  TMFCUT  = (float) tmfcut.getDoubleValue("window", 0,0,0); //acceptance window for TDC-FADC times
         
 	    int triggerPhase = 0;
     	
@@ -212,7 +214,7 @@ public class ECCommon {
                     float radc = (float)Math.sqrt(adc);
                     for (float tdcc : tdcs.getItem(is,il,ip)) {
                          float tdif = tps*tdcc - (float)gtw.getDoubleValue("time_walk",is,il,0)/radc - triggerPhase - FTOFFSET - t; 
-                        if (Math.abs(tdif)<10&&tdif<tmax) {tmax = tdif; tdc = (int)tdcc;}
+                        if (Math.abs(tdif)<TMFCUT&&tdif<tmax) {tmax = tdif; tdc = (int)tdcc;}
                     }
                     strip.setTDC(tdc); 
                 }              

--- a/reconstruction/ec/src/main/java/org/jlab/service/ec/ECCommon.java
+++ b/reconstruction/ec/src/main/java/org/jlab/service/ec/ECCommon.java
@@ -105,6 +105,7 @@ public class ECCommon {
 		IndexedTable      ggs = manager.getConstants(run, "/calibration/ec/global_gain_shift");
 		IndexedTable      gtw = manager.getConstants(run, "/calibration/ec/global_time_walk");
 		IndexedTable       ev = manager.getConstants(run, "/calibration/ec/effective_velocity");
+		IndexedTable      tgo = manager.getConstants(run, "/calibration/ec/tdc_global_offset");
     
         if (singleEvent) resetHistos();        
         
@@ -144,6 +145,8 @@ public class ECCommon {
                             time.getDoubleValue("a2", sector, layer, component),
                             time.getDoubleValue("a3", sector, layer, component),
                             time.getDoubleValue("a4", sector, layer, component));
+            strip.setGlobalTimingOffset(tgo.getDoubleValue("offset",0,0,0)); //global shift of TDC acceptance window
+
         }
             
         return ecStrips;

--- a/reconstruction/ec/src/main/java/org/jlab/service/ec/ECCommon.java
+++ b/reconstruction/ec/src/main/java/org/jlab/service/ec/ECCommon.java
@@ -12,7 +12,6 @@ import org.jlab.geom.component.ScintillatorPaddle;
 import org.jlab.groot.data.H1F;
 import org.jlab.io.base.DataBank;
 import org.jlab.io.base.DataEvent;
-import org.jlab.io.hipo.HipoDataEvent;
 import org.jlab.utils.groups.IndexedList;
 import org.jlab.utils.groups.IndexedTable;
 
@@ -111,7 +110,7 @@ public class ECCommon {
         
         List<ECStrip>  ecStrips = null;
         
-        if(event instanceof HipoDataEvent) ecStrips = ECCommon.readStripsHipo(event, run, manager);
+        ecStrips = ECCommon.readStripsHipo(event, run, manager); //lcs
         
         if(ecStrips==null) return new ArrayList<ECStrip>();
         

--- a/reconstruction/ec/src/main/java/org/jlab/service/ec/ECCommon.java
+++ b/reconstruction/ec/src/main/java/org/jlab/service/ec/ECCommon.java
@@ -110,7 +110,7 @@ public class ECCommon {
         
         List<ECStrip>  ecStrips = null;
         
-        ecStrips = ECCommon.readStripsHipo(event, run, manager); //lcs
+        ecStrips = ECCommon.readStripsHipo(event, run, manager);  
         
         if(ecStrips==null) return new ArrayList<ECStrip>();
         

--- a/reconstruction/ec/src/main/java/org/jlab/service/ec/ECEngine.java
+++ b/reconstruction/ec/src/main/java/org/jlab/service/ec/ECEngine.java
@@ -229,9 +229,11 @@ public class ECEngine extends ReconstructionEngine {
             "/calibration/ec/time_jitter",
             "/calibration/ec/fadc_offset",
             "/calibration/ec/fadc_global_offset",
+            "/calibration/ec/tdc_global_offset",
             "/calibration/ec/global_gain_shift",
             "/calibration/ec/global_time_walk",
-            "/calibration/ec/effective_velocity"
+            "/calibration/ec/effective_velocity",
+            "/calibration/ec/tmf_offset"
         };
         
         

--- a/reconstruction/ec/src/main/java/org/jlab/service/ec/ECEngine.java
+++ b/reconstruction/ec/src/main/java/org/jlab/service/ec/ECEngine.java
@@ -233,7 +233,8 @@ public class ECEngine extends ReconstructionEngine {
             "/calibration/ec/global_gain_shift",
             "/calibration/ec/global_time_walk",
             "/calibration/ec/effective_velocity",
-            "/calibration/ec/tmf_offset"
+            "/calibration/ec/tmf_offset",
+            "/calibration/ec/tmf_window"
         };
         
         

--- a/reconstruction/ec/src/main/java/org/jlab/service/ec/ECEngine.java
+++ b/reconstruction/ec/src/main/java/org/jlab/service/ec/ECEngine.java
@@ -14,9 +14,7 @@ import org.jlab.geom.base.Detector;
 import org.jlab.groot.data.H1F;
 import org.jlab.io.base.DataBank;
 import org.jlab.io.base.DataEvent;
-import org.jlab.io.evio.EvioDataEvent;
-import org.jlab.io.hipo.HipoDataEvent;
-import org.jlab.io.hipo.HipoDataSync;
+
 /**
  *
  * @author gavalian
@@ -24,10 +22,9 @@ import org.jlab.io.hipo.HipoDataSync;
 public class ECEngine extends ReconstructionEngine {
 
     EvioHipoEvent convertor = new EvioHipoEvent();            
-    HipoDataSync     writer = new HipoDataSync();
     CLASDecoder     decoder = new CLASDecoder();
     
-    Detector        ecDetector = null;
+    Detector              ecDetector = null;
     public Boolean             debug = false;
     public Boolean  isSingleThreaded = false;
     public Boolean       singleEvent = false;
@@ -74,7 +71,7 @@ public class ECEngine extends ReconstructionEngine {
             if(ecClusters.size()==2) {for(ECCluster c : ecClusters) System.out.println(c);}
         }
 	    
-        if(de instanceof HipoDataEvent) this.writeHipoBanks(de,ecStrips,ecPeaks,ecClusters);
+        this.writeHipoBanks(de,ecStrips,ecPeaks,ecClusters); //lcs
         
         if (isSingleThreaded) {
         	ECCommon.clearMyStructures();

--- a/reconstruction/ec/src/main/java/org/jlab/service/ec/ECEngine.java
+++ b/reconstruction/ec/src/main/java/org/jlab/service/ec/ECEngine.java
@@ -5,11 +5,9 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.jlab.clas.reco.ReconstructionEngine;
-import org.jlab.clas.reco.io.EvioHipoEvent;
 import org.jlab.detector.base.DetectorCollection;
 import org.jlab.detector.base.DetectorType;
 import org.jlab.detector.base.GeometryFactory;
-import org.jlab.detector.decode.CLASDecoder;
 import org.jlab.geom.base.Detector;
 import org.jlab.groot.data.H1F;
 import org.jlab.io.base.DataBank;
@@ -20,9 +18,6 @@ import org.jlab.io.base.DataEvent;
  * @author gavalian
  */
 public class ECEngine extends ReconstructionEngine {
-
-    EvioHipoEvent convertor = new EvioHipoEvent();            
-    CLASDecoder     decoder = new CLASDecoder();
     
     Detector              ecDetector = null;
     public Boolean             debug = false;
@@ -71,7 +66,7 @@ public class ECEngine extends ReconstructionEngine {
             if(ecClusters.size()==2) {for(ECCluster c : ecClusters) System.out.println(c);}
         }
 	    
-        this.writeHipoBanks(de,ecStrips,ecPeaks,ecClusters); //lcs
+        this.writeHipoBanks(de,ecStrips,ecPeaks,ecClusters);  
         
         if (isSingleThreaded) {
         	ECCommon.clearMyStructures();

--- a/reconstruction/ec/src/main/java/org/jlab/service/ec/ECPeak.java
+++ b/reconstruction/ec/src/main/java/org/jlab/service/ec/ECPeak.java
@@ -124,11 +124,11 @@ public class ECPeak {
             Line3D line = this.peakStrips.get(i).getLine();
             
             double energy = this.peakStrips.get(i).getEnergy();
-//            double     le = Math.log(energy);
+//            double     le = Math.log(energy);  //ECReconstructionTest fails to find PCAL cluster for this choice
             double     le = energy;
             
             this.peakDistanceEdge += 
-                    //peakStrips.get(i).getDistanceEdge() + 
+//                    peakStrips.get(i).getDistanceEdge() + 
                     peakStrips.get(i).getDistanceEdge()*le;
             
             pointOrigin.setX(pointOrigin.x()+line.origin().x()*le);

--- a/reconstruction/ec/src/main/java/org/jlab/service/ec/ECStrip.java
+++ b/reconstruction/ec/src/main/java/org/jlab/service/ec/ECStrip.java
@@ -27,6 +27,7 @@ public class ECStrip implements Comparable {
     private double    iAttenLengthA = 1.0;
     private double    iAttenLengthB = 50000.0;
     private double    iAttenLengthC = 0.0;
+    private double        iTiming00 = 0; // Global TDC offset
 	private double        iTimingA0 = 0; // Offset in ns (before applying a1)
 	private double        iTimingA1 = 1; // ns -> TDC conv. factor (TDC = ns/a1)
 	private double        iTimingA2 = 0; // time-walk factor (time_ns = time_ns + a2/sqrt(adc))
@@ -137,12 +138,12 @@ public class ECStrip implements Comparable {
         
         public double getTWCTime() {
         	double radc = Math.sqrt(iADC);
-          	return getPhaseCorrectedTime() - gtw/radc - iTimingA2/radc - iTimingA3 - iTimingA4/Math.sqrt(radc);          	
+          	return getPhaseCorrectedTime() - gtw/radc - iTimingA2/radc - iTimingA3 - iTimingA4/Math.sqrt(radc) - iTiming00;          	
         } 
         
     	public double getTime() {
         	double radc = Math.sqrt(iADC);
-          	return getPhaseCorrectedTime() - gtw/radc - iTimingA2/radc - iTimingA3 - iTimingA4/Math.sqrt(radc) - iTimingA0;          	
+          	return getPhaseCorrectedTime() - gtw/radc - iTimingA2/radc - iTimingA3 - iTimingA4/Math.sqrt(radc) - iTimingA0 - iTiming00;          	
         }         
     } 
     
@@ -195,6 +196,10 @@ public class ECStrip implements Comparable {
 		this.iTimingA3 = a3;
 		this.iTimingA4 = a4;
 	}  
+	
+	public void setGlobalTimingOffset(double val) {
+		this.iTiming00 = val;
+	}
 	
 	public double[] getTiming() {
 		double[] array = new double[5];

--- a/reconstruction/ec/src/test/java/org/jlab/service/ec/ECReconstructionTest.java
+++ b/reconstruction/ec/src/test/java/org/jlab/service/ec/ECReconstructionTest.java
@@ -31,7 +31,7 @@ public class ECReconstructionTest {
     
     assertEquals(testEvent.hasBank("FAKE::Bank"), false);
     assertEquals(testEvent.hasBank("ECAL::clusters"), true);
-    assertEquals(testEvent.getBank("ECAL::clusters").rows(), 3);
+    assertEquals(testEvent.getBank("ECAL::clusters").rows(), 3);    
   }
 
 }


### PR DESCRIPTION
All changes compatible with GEMC and previous release

o Global timewalk correction now used in FADC-TDC calculation
o FADC-TDC offsets now at both global and local (PMT) level
o FADC-TDC cuts reduced from 30 ns to 10 ns.
o /calibration/ec/tdc_global_offset initialized
o /calibration/ec/tmf_offset initialized
o /calibration/ec/tmf_window initialized
o Replace hardcoded TDC-fADC window cut with CCDB tmf_window
o Implement /calibration/ec/tdc_global_offset