### PR TITLE
Last DST bank changes

### DIFF
--- a/common-tools/clas-analysis/src/main/java/org/jlab/analysis/physics/TestEvent.java
+++ b/common-tools/clas-analysis/src/main/java/org/jlab/analysis/physics/TestEvent.java
@@ -33,7 +33,7 @@ public class TestEvent {
 		config.putFloat("solenoid", 0, (float) 0.0);
 		
                 Bank event = new Bank(schemaFactory.getSchema("RECHB::Event"), 1);
-		event.putFloat("STTime", 0, (float) 124.25);
+		event.putFloat("startTime", 0, (float) 124.25);
 
 
                 int[] layer = {    1,   2,   3,   4,   5,   6,   7,   8,   9,  10

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/CLASDecoder4.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/CLASDecoder4.java
@@ -471,7 +471,6 @@ public class CLASDecoder4 {
         int   localTime = this.codaDecoder.getUnixTime();
         long  timeStamp = this.codaDecoder.getTimeStamp();
         long triggerBits = this.codaDecoder.getTriggerBits();
-        byte  helicityL3 = this.codaDecoder.getHelicityLevel3();
 
         if(nrun>0){
             localRun = nrun;
@@ -488,10 +487,6 @@ public class CLASDecoder4 {
         }
         */
 
-        // retrieve fcup calibrations from CCDB:
-        IndexedTable hwpTable = this.detectorDecoder.scalerManager.
-                getConstants(this.detectorDecoder.getRunNumber(),"/runcontrol/hwp");
-
         bank.putInt("run",        0, localRun);
         bank.putInt("event",      0, localEvent);
         bank.putInt("unixtime",   0, localTime);
@@ -499,9 +494,18 @@ public class CLASDecoder4 {
         bank.putFloat("torus",    0, torus);
         bank.putFloat("solenoid", 0, solenoid);
         bank.putLong("timestamp", 0, timeStamp);
-        bank.putByte("helicityRawL3",0, helicityL3);
-        bank.putByte("helicityL3",0,(byte)(helicityL3*hwpTable.getIntValue("hwp",0,0,0)));
 
+        return bank;
+    }
+
+    public Bank createOnlineHelicityBank() {
+        if (schemaFactory.hasSchema("HEL::online")==false) return null;
+        Bank bank = new Bank(schemaFactory.getSchema("HEL::online"), 1);
+        byte  helicityL3 = this.codaDecoder.getHelicityLevel3();
+        IndexedTable hwpTable = this.detectorDecoder.scalerManager.
+                getConstants(this.detectorDecoder.getRunNumber(),"/runcontrol/hwp");
+        bank.putByte("helicityRaw",0, helicityL3);
+        bank.putByte("helicity",0,(byte)(helicityL3*hwpTable.getIntValue("hwp",0,0,0)));
         return bank;
     }
 
@@ -708,6 +712,8 @@ public class CLASDecoder4 {
                     if(header!=null) decodedEvent.write(header);
                     Bank   trigger = decoder.createTriggerBank();
                     if(trigger!=null) decodedEvent.write(trigger);
+                    Bank onlineHelicity = decoder.createOnlineHelicityBank();
+                    if(onlineHelicity!=null) decodedEvent.write(onlineHelicity);
                     //decodedEvent.appendBanks(header);
                     //decodedEvent.appendBanks(trigger);
 

--- a/common-tools/clas-reco/src/main/java/org/jlab/clas/detector/DetectorData.java
+++ b/common-tools/clas-reco/src/main/java/org/jlab/clas/detector/DetectorData.java
@@ -315,13 +315,12 @@ public class DetectorData {
 
    public static DataBank getEventBank(DetectorEvent detectorEvent, DataEvent event, String bank_name){
        DataBank bank = event.createBank(bank_name, 1);
-       bank.setLong("TRG", 0, detectorEvent.getEventHeader().getTrigger());
        bank.setFloat("STTime", 0, (float) detectorEvent.getEventHeader().getStartTime());
        bank.setFloat("RFTime", 0, (float) detectorEvent.getEventHeader().getRfTime());
-       bank.setByte("Helic", 0, detectorEvent.getEventHeader().getHelicity());
-       bank.setFloat("BCG", 0, detectorEvent.getEventHeader().getBeamChargeGated());
-       bank.setDouble("LT", 0, detectorEvent.getEventHeader().getLivetime());
-       bank.setShort("EvCAT", 0, detectorEvent.getEventHeader().getEventCategory());
+       bank.setByte("helicity", 0, detectorEvent.getEventHeader().getHelicity());
+       bank.setByte("helicityRaw", 0, detectorEvent.getEventHeader().getHelicityRaw());
+       bank.setFloat("beamCharge", 0, detectorEvent.getEventHeader().getBeamChargeGated());
+       bank.setDouble("liveTime", 0, detectorEvent.getEventHeader().getLivetime());
        return bank;
    }
    public static DataBank getEventShadowBank(DetectorEvent detectorEvent, DataEvent event, String bank_name){

--- a/common-tools/clas-reco/src/main/java/org/jlab/clas/detector/DetectorData.java
+++ b/common-tools/clas-reco/src/main/java/org/jlab/clas/detector/DetectorData.java
@@ -315,7 +315,7 @@ public class DetectorData {
 
    public static DataBank getEventBank(DetectorEvent detectorEvent, DataEvent event, String bank_name){
        DataBank bank = event.createBank(bank_name, 1);
-       bank.setFloat("STTime", 0, (float) detectorEvent.getEventHeader().getStartTime());
+       bank.setFloat("startTime", 0, (float) detectorEvent.getEventHeader().getStartTime());
        bank.setFloat("RFTime", 0, (float) detectorEvent.getEventHeader().getRfTime());
        bank.setByte("helicity", 0, detectorEvent.getEventHeader().getHelicity());
        bank.setByte("helicityRaw", 0, detectorEvent.getEventHeader().getHelicityRaw());
@@ -325,7 +325,7 @@ public class DetectorData {
    }
    public static DataBank getEventShadowBank(DetectorEvent detectorEvent, DataEvent event, String bank_name){
        DataBank bank = event.createBank(bank_name, 1);
-       bank.setFloat("STTime", 0, (float) detectorEvent.getEventHeader().getStartTimeFT());
+       bank.setFloat("startTime", 0, (float) detectorEvent.getEventHeader().getStartTimeFT());
        bank.setShort("EvCAT", 0, detectorEvent.getEventHeader().getEventCategoryFT());
        return bank;
    }

--- a/common-tools/clas-reco/src/main/java/org/jlab/clas/detector/DetectorHeader.java
+++ b/common-tools/clas-reco/src/main/java/org/jlab/clas/detector/DetectorHeader.java
@@ -13,6 +13,7 @@ public class DetectorHeader {
     private double  startTime = -1000.0;
     private double startTimeFT = -1000.0;
     private byte     helicity = 0;
+    private byte     helicityRaw = 0;
     private float beamChargeGated = 0;
     private float    livetime = -1;
     private short eventCategory = 0;
@@ -47,6 +48,10 @@ public class DetectorHeader {
 
     public byte getHelicity() {
 	 return helicity;
+    }
+
+    public byte getHelicityRaw() {
+	 return helicityRaw;
     }
 
     public float getLivetime() {
@@ -91,6 +96,10 @@ public class DetectorHeader {
 
     public void setHelicity(byte helicity) {
         this.helicity = helicity;
+    }
+
+    public void setHelicityRaw(byte helicity) {
+        this.helicityRaw = helicity;
     }
 
     public void setBeamChargeGated(float bcg) {

--- a/etc/bankdefs/hipo4/data.json
+++ b/etc/bankdefs/hipo4/data.json
@@ -421,6 +421,16 @@
       ]
   },
   {
+      "name": "HEL::online",
+      "group": 22000,
+      "item":  13,
+      "info": "Helicity with online delay-correction in Level3 trigger",
+      "entries":[
+          {"name":"helicity",   "type":"B", "info":"online-delay-corrected helicity, with HWP-correction (0=UDF)"},
+          {"name":"helicityRaw","type":"B", "info":"online-delay-corrected helicity (0=UDF)"}
+      ]
+  },
+  {
     "name" : "RAW::adc",
     "group": 20000,
     "item" : 11,

--- a/etc/bankdefs/hipo4/event.json
+++ b/etc/bankdefs/hipo4/event.json
@@ -9,7 +9,7 @@
                 {"name":"topology",   "type":"L", "info":"Undefined"},
                 {"name":"beamCharge", "type":"F", "info":"Beam charge, gated (nano-Coulomb)"},
                 {"name":"liveTime",   "type":"D", "info":"Lifetime"},
-                {"name":"STTime",     "type":"F", "info":"Event Start Time (ns)"},
+                {"name":"startTime",  "type":"F", "info":"Event Start Time (ns)"},
                 {"name":"RFTime",     "type":"F", "info":"RF Time (ns)"},
                 {"name":"helicity",   "type":"B", "info":"Helicity of Event (0 or 1, else undefined), with HWP-correction"},
                 {"name":"helicityRaw","type":"B", "info":"Helicity of Event (0 or 1, else undefined)"},
@@ -188,7 +188,7 @@
                 {"name":"topology",   "type":"L", "info":"Undefined"},
                 {"name":"beamCharge", "type":"F", "info":"Beam charge, gated (nano-Coulomb)"},
                 {"name":"liveTime",   "type":"D", "info":"Lifetime"},
-                {"name":"STTime",     "type":"F", "info":"Event Start Time (ns)"},
+                {"name":"startTime",  "type":"F", "info":"Event Start Time (ns)"},
                 {"name":"RFTime",     "type":"F", "info":"RF Time (ns)"},
                 {"name":"helicity",   "type":"B", "info":"Helicity of Event (0 or 1, else undefined), with HWP-correction"},
                 {"name":"helicityRaw","type":"B", "info":"Helicity of Event (0 or 1, else undefined)"},
@@ -418,7 +418,6 @@
             {"name":"index",   "type":"S", "info":"index of the track in its tracking bank"},
             {"name":"detector","type":"B", "info":"DetectorID as defined in org.jlab.detector.DetectorType"},
             {"name":"layer",   "type":"B", "info":"Layer ID as defined in org.jlab.detector.DetectorLayer"},
-            {"name":"q",       "type":"B", "info":"charge of the track"},
             {"name":"x",       "type":"F", "info":"x-position of the track at the detector surface (cm)"},
             {"name":"y",       "type":"F", "info":"y-position of the track at the detector surface (cm)"},
             {"name":"z",       "type":"F", "info":"z-position of the track at the detector surface (cm)"},
@@ -434,8 +433,8 @@
         "item": 41,
         "info": "Event Header Bank, shadowing REC::Event with FT-based start time",
         "entries": [
-            {"name":"EvCAT",    "id":1, "type":"S", "info":"Event Category, if >0:  e-, e-p, e-pi+....."},
-            {"name":"STTime",   "id":2, "type":"F", "info":"Event Start Time (ns)"}
+            {"name":"EvCAT",     "type":"S", "info":"Event Category, if >0:  e-, e-p, e-pi+....."},
+            {"name":"startTime", "type":"F", "info":"Event Start Time (ns)"}
         ]
     },
     {
@@ -444,10 +443,10 @@
         "item" : 42,
         "info": "Reconstructed Particle Information, shadowing REC::Particle with FT-based start time",
         "entries": [
-            {"name":"pid",          "id":1,  "type":"I", "info":"particle id in LUND conventions"},
-            {"name":"beta",         "id":2,  "type":"F", "info":"particle beta measured by TOF"},
-            {"name":"chi2pid",      "id":3,  "type":"F", "info":"Chi2 of assigned PID"},
-            {"name":"status",       "id":4,  "type":"S", "info":"particle status (represents detector collection it passed)"}
+            {"name":"pid",     "type":"I", "info":"particle id in LUND conventions"},
+            {"name":"beta",    "type":"F", "info":"particle beta measured by TOF"},
+            {"name":"chi2pid", "type":"F", "info":"Chi2 of assigned PID"},
+            {"name":"status",  "type":"S", "info":"particle status (represents detector collection it passed)"}
         ]
     }
 ]

--- a/etc/bankdefs/hipo4/event.json
+++ b/etc/bankdefs/hipo4/event.json
@@ -5,17 +5,15 @@
         "item": 10,
         "info": "Event Header Bank",
         "entries": [
-                {"name":"EVNTime",  "type":"F", "info":"Event Time"},
-                {"name":"TYPE",     "type":"B", "info":"Event Type (Data or MC)"},
-                {"name":"EvCAT",    "type":"S", "info":"Event Category, if >0:  e-, e-p, e-pi+....."},
-                {"name":"NPGP",     "type":"S", "info":"Number of Final (Timed-based) Reconstructed Particles*100 + Number of Geometrically Reconstructed Particles"},
-                {"name":"TRG",      "type":"L", "info":"Trigger Type (CLAS12_e-, FT_CLAS12_h, CLAS12_H,...) + Prescale Factor for that Trigger"},
-                {"name":"BCG",      "type":"F", "info":"Beam charge, gated (nano-Coulomb)"},
-                {"name":"LT",       "type":"D", "info":"Lifetime"},
-                {"name":"STTime",   "type":"F", "info":"Event Start Time (ns)"},
-                {"name":"RFTime",   "type":"F", "info":"RF Time (ns)"},
-                {"name":"Helic",    "type":"B", "info":"Helicity of Event (0 or 1, else undefined)"},
-                {"name":"PTIME",    "type":"F", "info":"Event Processing Time (UNIX Time = seconds)"}
+                {"name":"category",   "type":"L", "info":"Undefined"},
+                {"name":"topology",   "type":"L", "info":"Undefined"},
+                {"name":"beamCharge", "type":"F", "info":"Beam charge, gated (nano-Coulomb)"},
+                {"name":"liveTime",   "type":"D", "info":"Lifetime"},
+                {"name":"STTime",     "type":"F", "info":"Event Start Time (ns)"},
+                {"name":"RFTime",     "type":"F", "info":"RF Time (ns)"},
+                {"name":"helicity",   "type":"B", "info":"Helicity of Event (0 or 1, else undefined), with HWP-correction"},
+                {"name":"helicityRaw","type":"B", "info":"Helicity of Event (0 or 1, else undefined)"},
+                {"name":"procTime",   "type":"F", "info":"Event Processing Time (UNIX Time = seconds)"}
             ]
     },
     {
@@ -186,17 +184,15 @@
         "item" : 30,
         "info": "Event Header Bank",
         "entries": [
-                {"name":"EVNTime",  "type":"F", "info":"Event Time"},
-                {"name":"TYPE",     "type":"B", "info":"Event Type (Data or MC)"},
-                {"name":"EvCAT",    "type":"S", "info":"Event Category, if >0:  e-, e-p, e-pi+....."},
-                {"name":"NPGP",     "type":"S", "info":"Number of Final (Timed-based) Reconstructed Particles*100 + Number of Geometrically Reconstructed Particles"},
-                {"name":"TRG",      "type":"L", "info":"Trigger Type (CLAS12_e-, FT_CLAS12_h, CLAS12_H,...) + Prescale Factor for that Trigger"},
-                {"name":"BCG",      "type":"F", "info":"Faraday Cup Gated (nano-Coulomb)"},
-                {"name":"LT",       "type":"D", "info":"Clock"},
-                {"name":"STTime",   "type":"F", "info":"Event Start Time (ns)"},
-                {"name":"RFTime",   "type":"F", "info":"RF Time (ns)"},
-                {"name":"Helic",    "type":"B", "info":"Helicity of Event (0 or 1 else undefined)"},
-                {"name":"PTIME",    "type":"F", "info":"Event Processing Time (UNIX Time = seconds)"}
+                {"name":"category",   "type":"L", "info":"Undefined"},
+                {"name":"topology",   "type":"L", "info":"Undefined"},
+                {"name":"beamCharge", "type":"F", "info":"Beam charge, gated (nano-Coulomb)"},
+                {"name":"liveTime",   "type":"D", "info":"Lifetime"},
+                {"name":"STTime",     "type":"F", "info":"Event Start Time (ns)"},
+                {"name":"RFTime",     "type":"F", "info":"RF Time (ns)"},
+                {"name":"helicity",   "type":"B", "info":"Helicity of Event (0 or 1, else undefined), with HWP-correction"},
+                {"name":"helicityRaw","type":"B", "info":"Helicity of Event (0 or 1, else undefined)"},
+                {"name":"procTime",   "type":"F", "info":"Event Processing Time (UNIX Time = seconds)"}
             ]
     },
     {

--- a/etc/bankdefs/hipo4/header.json
+++ b/etc/bankdefs/hipo4/header.json
@@ -13,9 +13,7 @@
             {"name":"type",         "type":"B", "info":"type of the run"},
             {"name":"mode",         "type":"B", "info":"run mode"},
             {"name":"torus",        "type":"F", "info":"torus setting relative value(-1.0 to 1.0)"},
-            {"name":"solenoid",     "type":"F", "info":"solenoid field setting (-1.0 to 1.0)"},
-            {"name":"helicityL3",   "type":"B", "info":"online-delay-corrected helicity, with HWP-correction (0=UDF)"},
-            {"name":"helicityRawL3","type":"B", "info":"online-delay-corrected helicity (0=UDF)"}
+            {"name":"solenoid",     "type":"F", "info":"solenoid field setting (-1.0 to 1.0)"}
         ]
     },
     {

--- a/reconstruction/dc/src/main/java/org/jlab/rec/dc/banks/HitReader.java
+++ b/reconstruction/dc/src/main/java/org/jlab/rec/dc/banks/HitReader.java
@@ -303,7 +303,7 @@ public class HitReader {
                     event.getBank("RUN::config").getInt("run", 0) > 100) {
                 T_0 = this.get_T0(sector[i], slayer[i], layer[i], wire[i], T0, T0ERR)[0];
                 if (event.hasBank("RECHB::Event"))
-                    T_Start = event.getBank("RECHB::Event").getFloat("STTime", 0);
+                    T_Start = event.getBank("RECHB::Event").getFloat("startTime", 0);
             }
 
             FittedHit hit = new FittedHit(sector[i], slayer[i], layer[i], wire[i], tdc[i], id[i]);
@@ -375,7 +375,7 @@ public class HitReader {
         int[] trkID = new int[rows];
         double[] tProp = new double[rows];
         double[] tFlight = new double[rows];
-        double startTime = (double) event.getBank("REC::Event").getFloat("STTime", 0);
+        double startTime = (double) event.getBank("REC::Event").getFloat("startTime", 0);
 
         if (startTime < 0)
             return;

--- a/reconstruction/dc/src/main/java/org/jlab/service/dc/DCTBEngine.java
+++ b/reconstruction/dc/src/main/java/org/jlab/service/dc/DCTBEngine.java
@@ -59,7 +59,7 @@ public class DCTBEngine extends DCEngine {
             System.err.println("RUN CONDITIONS NOT READ AT TIMEBASED LEVEL!");
             return true;
         }
-        //if(event.getBank("RECHB::Event").getFloat("STTime", 0)<0)
+        //if(event.getBank("RECHB::Event").getFloat("startTime", 0)<0)
         //    return true; // require the start time to reconstruct the tracks in the event
         
         DataBank bank = event.getBank("RUN::config");
@@ -74,7 +74,7 @@ public class DCTBEngine extends DCEngine {
         double T_Start = 0;
         if(Constants.isUSETSTART() == true) {
             if(event.hasBank("RECHB::Event")==true) {
-                T_Start = event.getBank("RECHB::Event").getFloat("STTime", 0);
+                T_Start = event.getBank("RECHB::Event").getFloat("startTime", 0);
                 if(T_Start<0) {
                     return true; // quit if start time not found in data
                 }

--- a/reconstruction/dc/src/main/java/org/jlab/service/dc/LayerEfficiencyAnalyzer.java
+++ b/reconstruction/dc/src/main/java/org/jlab/service/dc/LayerEfficiencyAnalyzer.java
@@ -280,7 +280,7 @@ public class LayerEfficiencyAnalyzer extends DCEngine implements IDataEventListe
             System.err.println("RUN CONDITIONS NOT READ AT TIMEBASED LEVEL!");
             return true;
         }
-        //if(event.getBank("RECHB::Event").getFloat("STTime", 0)<0)
+        //if(event.getBank("RECHB::Event").getFloat("startTime", 0)<0)
         //    return true; // require the start time to reconstruct the tracks in the event
         
         DataBank bank = event.getBank("RUN::config");
@@ -293,7 +293,7 @@ public class LayerEfficiencyAnalyzer extends DCEngine implements IDataEventListe
         double T_Start = 0;
         if(Constants.isUSETSTART() == true) {
             if(event.hasBank("RECHB::Event")==true) {
-                T_Start = event.getBank("RECHB::Event").getFloat("STTime", 0);
+                T_Start = event.getBank("RECHB::Event").getFloat("startTime", 0);
                 if(T_Start<0) {
                     return true; // quit if start time not found in data
                 }

--- a/reconstruction/eb/src/main/java/org/jlab/rec/eb/EBCCDBConstants.java
+++ b/reconstruction/eb/src/main/java/org/jlab/rec/eb/EBCCDBConstants.java
@@ -40,6 +40,7 @@ public class EBCCDBConstants {
     private static final String[] otherTableNames={
         "/runcontrol/fcup",
         "/runcontrol/hwp",
+        "/runcontrol/helicity",
         "/geometry/target",
         "/calibration/ftof/tres",
         //"/calibration/ctof/tres"
@@ -300,6 +301,12 @@ public class EBCCDBConstants {
         loadInteger(EBCCDBEnum.RF_JITTER_CYCLES,"rf/jitter","cycles",0,0,0);
         loadInteger(EBCCDBEnum.RF_JITTER_PHASE ,"rf/jitter","phase",0,0,0);
         loadDouble(EBCCDBEnum.RF_JITTER_PERIOD,"rf/jitter","period",0,0,0);
+
+        loadDouble(EBCCDBEnum.HELICITY_frequency,"/runcontrol/helicity","frequency",0,0,0);
+        loadDouble(EBCCDBEnum.HELICITY_tsettle,"/runcontrol/helicity","tsettle",0,0,0);
+        loadDouble(EBCCDBEnum.HELICITY_tstable,"/runcontrol/helicity","tstable",0,0,0);
+        loadInteger(EBCCDBEnum.HELICITY_delay,"/runcontrol/helicity","delay",0,0,0);
+        loadInteger(EBCCDBEnum.HELICITY_pattern,"/runcontrol/helicity","pattern",0,0,0);
         
         //this.show();
         currentRun = run;

--- a/reconstruction/eb/src/main/java/org/jlab/rec/eb/EBCCDBEnum.java
+++ b/reconstruction/eb/src/main/java/org/jlab/rec/eb/EBCCDBEnum.java
@@ -59,6 +59,11 @@ public enum EBCCDBEnum {
     FCUP_slope,
     FCUP_offset,
     FCUP_atten,
+    HELICITY_frequency,
+    HELICITY_delay,
+    HELICITY_pattern,
+    HELICITY_tsettle,
+    HELICITY_tstable,
     HWP_position;
 }
 

--- a/reconstruction/eb/src/main/java/org/jlab/service/eb/EBio.java
+++ b/reconstruction/eb/src/main/java/org/jlab/service/eb/EBio.java
@@ -35,7 +35,7 @@ public class EBio {
         }
 
         // helicity:
-        if(event.hasBank("HEL::adc")) {
+        if(ccdb.getInteger(EBCCDBEnum.HELICITY_delay)==0 && event.hasBank("HEL::adc")) {
             final int helComponent=1;
             final int helHalf=2000;
             DataBank bank = event.getBank("HEL::adc");

--- a/reconstruction/eb/src/main/java/org/jlab/service/eb/EBio.java
+++ b/reconstruction/eb/src/main/java/org/jlab/service/eb/EBio.java
@@ -43,9 +43,8 @@ public class EBio {
                 if (bank.getInt("component",ii)==helComponent) {
                     byte helicity=-1;
                     if (bank.getInt("ped",ii)>helHalf) helicity=1;
-                    // correct for HWP position:
-                    helicity *= ccdb.getInteger(EBCCDBEnum.HWP_position);
-                    dHeader.setHelicity(helicity);
+                    dHeader.setHelicityRaw(helicity);
+                    dHeader.setHelicity((byte)(helicity*ccdb.getInteger(EBCCDBEnum.HWP_position)));
                     break;
                 }
             }

--- a/validation/advanced-tests/src/eb/EBTwoTrackTest.java
+++ b/validation/advanced-tests/src/eb/EBTwoTrackTest.java
@@ -508,7 +508,7 @@ public class EBTwoTrackTest {
             recPartBank.show();
         }
 
-        final float startTime=recBank.getFloat("STTime",0);
+        final float startTime=recBank.getFloat("startTime",0);
 
         for (int ii=0; ii<recPartBank.rows(); ii++) {
             if (recPartBank.getShort("status",ii)/1000 == 1) {


### PR DESCRIPTION
* Move RUN::config.helicityL3 to new bank, HEL::online
* Remove REC::Traj.q
* Rename REC::Event variables
  * STTime to startTime
  * BCG to beamCharge
  * LT to liveTime
  * EvCat to category
  * NPGP to topology
  * PTIME to procTime
  * Helic to helicity
* Remove REC::Event variables
  * EVNTime
  * TYPE
  * TRG
* Only fill REC::Event.helicity if non-delayed for now (based on CCDB's /runcontrol/helicity)
