### PR TITLE
Helicity Analysis updates

### DIFF
--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/HelicityAnalysis.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/HelicityAnalysis.java
@@ -1,0 +1,133 @@
+package org.jlab.detector.helicity;
+
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import org.jlab.jnp.hipo4.io.HipoReader;
+import org.jlab.jnp.hipo4.data.Event;
+import org.jlab.jnp.hipo4.data.Bank;
+import org.jlab.jnp.hipo4.data.SchemaFactory;
+
+/**
+ * An example of reading the helicity flips and analyzing the sequence.
+ * 
+ * @author baltzell
+ */
+public class HelicityAnalysis {
+
+    /**
+     * This reads tag=1 events for HEL::flip banks, and initializes
+     * a helicity sequence with delay set to zero.  The delay can be
+     * changed later before a user tries to access the sequence.
+     * 
+     * @param filenames = list of names of HIPO file to read
+     * @return  unanalyzed HelicitySequence 
+     */
+    public static HelicitySequenceDelayed readSequence(List<String> filenames) {
+        
+        HelicitySequenceDelayed seq=new HelicitySequenceDelayed(0);
+        seq.setVerbosity(3);
+       
+        for (String filename : filenames) {
+
+            HipoReader reader = new HipoReader();
+            reader.setTags(1);
+            reader.open(filename);
+        
+            SchemaFactory schema = reader.getSchemaFactory();
+        
+            while (reader.hasNext()) {
+            
+                Event event=new Event();
+                Bank flipBank=new Bank(schema.getSchema("HEL::flip"));
+            
+                reader.nextEvent(event);
+                event.read(flipBank);
+            
+                if (flipBank.getRows()<1) continue;
+        
+                seq.addState(HelicityState.createFromFlipBank(flipBank));
+            }
+
+            reader.close();
+        }
+        
+        return seq;
+    }
+    
+    public static void main(String[] args) {
+        
+        final String dir="/Users/baltzell/data/CLAS12/rg-b/decoded/";
+        final String file="clas_006432.evio.00041-00042.hipo";
+
+        List<String> filenames=new ArrayList<>();
+        if (args.length>0) filenames.addAll(Arrays.asList(args));
+        else               filenames.add(dir+file);
+       
+        // initialize a sequence from files (tag=1 events):
+        HelicitySequenceDelayed seq = HelicityAnalysis.readSequence(filenames);
+        final boolean integrity = seq.analyze();
+        if (!integrity) System.err.println("\n\n######### OOPS\n\n");
+
+        // print the sequence:
+        seq.show();
+
+        // set the appropriate delay for this data:
+        seq.setDelay(8);
+
+        // now read the full events, e.g. during a normal physics analysis: 
+        int nevents=0;
+        int nflips=0;
+       
+        for (String filename : filenames) {
+
+            HipoReader reader = new HipoReader();
+            reader.setTags(0);
+            reader.open(filename);
+            
+            SchemaFactory schema = reader.getSchemaFactory();
+        
+            while (reader.hasNext()) {
+
+                nevents++;
+                
+                Bank flipBank=new Bank(schema.getSchema("HEL::flip"));
+                Bank rcfgBank=new Bank(schema.getSchema("RUN::config"));
+                Bank onliBank=new Bank(schema.getSchema("HEL::online"));
+               
+                Event event=new Event();
+                reader.nextEvent(event);
+                event.read(flipBank);
+                event.read(rcfgBank);
+                event.read(onliBank);
+            
+                // just to curtail printouts:
+                if (flipBank.getRows()>0) nflips++;
+                if (nflips<240) continue;
+                if (nevents%100!=0) continue;
+         
+                long timestamp = -1;
+                HelicityBit level3 = HelicityBit.UDF;
+                HelicityBit predicted = HelicityBit.UDF;
+                HelicityBit measured = HelicityBit.UDF;
+                
+                // read 'em if we've got 'em:
+                if (rcfgBank.getRows()>0) 
+                    timestamp = rcfgBank.getLong("timestamp",0);
+                if (onliBank.getRows()>0)
+                    level3 = HelicityBit.create(onliBank.getByte("helicity",0));
+                if (seq.find(timestamp)!=null)
+                    measured = seq.find(timestamp);
+                if (seq.findPrediction(timestamp)!=null)
+                    predicted = seq.findPrediction(timestamp);
+
+                System.out.println(String.format("%d %5d L3/Predict/Measured = %6s%6s%6s",
+                        timestamp,nflips,level3,predicted,measured));
+            }
+
+            reader.close();
+
+        }
+    }
+}

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/HelicityBit.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/HelicityBit.java
@@ -14,7 +14,7 @@ public enum HelicityBit {
     PLUS  (  1 ),
     MINUS ( -1 );
 
-    private final int value;
+    private int value;
 
     HelicityBit(int value) {
         this.value=value;
@@ -26,6 +26,12 @@ public enum HelicityBit {
         for(HelicityBit hb: HelicityBit.values()) {
             if (hb.value() == value) return hb;
         }
+        return UDF;
+    }
+
+    public static HelicityBit getFlipped(HelicityBit bit) {
+        if (bit==PLUS) return MINUS;
+        if (bit==MINUS) return PLUS;
         return UDF;
     }
 

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/HelicityBit.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/HelicityBit.java
@@ -14,7 +14,7 @@ public enum HelicityBit {
     PLUS  (  1 ),
     MINUS ( -1 );
 
-    private int value;
+    private final int value;
 
     HelicityBit(int value) {
         this.value=value;

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/HelicityGenerator.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/HelicityGenerator.java
@@ -71,8 +71,7 @@ public final class HelicityGenerator {
      * Requires initialized()==true.
      */
     private void shiftRegister() {
-        final int nextBit = this.getNextBit();
-        this.shiftRegister(nextBit);
+        this.shiftRegister(this.getNextBit());
     }
 
     /**
@@ -124,27 +123,4 @@ public final class HelicityGenerator {
         return this.states.get(n) == 0 ?
             HelicityBit.PLUS : HelicityBit.MINUS;
     }
-
-    public static void main(String[] args) {
-        HelicityGenerator hg=new HelicityGenerator();
-        // invent and load some pattern:
-        while (!hg.initialized()) {
-            hg.addState(HelicityBit.MINUS);
-            hg.addState(HelicityBit.PLUS);
-            if (hg.initialized()) break;
-            hg.addState(HelicityBit.PLUS);
-            hg.addState(HelicityBit.MINUS);
-            if (hg.initialized()) break;
-            hg.addState(HelicityBit.PLUS);
-            hg.addState(HelicityBit.MINUS);
-            if (hg.initialized()) break;
-            hg.addState(HelicityBit.MINUS);
-            hg.addState(HelicityBit.PLUS);
-        }
-        for (int ii=0; ii<50; ii++) {
-            System.out.println(ii+" "+hg.getState(ii));
-        }
-    }
-
 }
-

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/HelicitySequence.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/HelicitySequence.java
@@ -214,7 +214,7 @@ public class HelicitySequence implements Comparator<HelicityState> {
     public void show() {
         HelicityState prev=this.states.get(0);
         for (int ii=0; ii<this.states.size(); ii++) {
-            if (this.states.get(ii).getQuartet()==HelicityBit.PLUS) continue;
+            if (this.states.get(ii).getPatternSync()==HelicityBit.PLUS) continue;
             System.out.println(String.format("%4d %6s %6s %6s",
                     ii,
                     this.get(ii).getInfo(prev,ii),
@@ -276,7 +276,7 @@ public class HelicitySequence implements Comparator<HelicityState> {
         for (int ii=0; ii<this.states.size(); ii++) {
             // generator operates on the pattern sync:
             if (!this.generator.initialized() &&
-                 this.states.get(ii).getQuartet()==HelicityBit.MINUS) {
+                 this.states.get(ii).getPatternSync()==HelicityBit.MINUS) {
                 if (this.generator.size()==0) {
                     this.generatorOffset=ii;
                 }
@@ -310,17 +310,17 @@ public class HelicitySequence implements Comparator<HelicityState> {
             }
             
             // check if neighboring syncs are the same (they shouldn't be):
-            if (this.states.get(ii).getSync().value() == this.states.get(ii-1).getSync().value()) {
+            if (this.states.get(ii).getPairSync().value() == this.states.get(ii-1).getPairSync().value()) {
                 syncErrors++;
                 if (debug>1) System.err.println("ERROR: HelicitySequence SYNC: "+ii);
             }
 
             // check if quartet sequence is broken (should be 1minus + 3plus):
             if (ii > 2) {
-                if (this.states.get(ii-0).getQuartet().value()+
-                    this.states.get(ii-1).getQuartet().value()+
-                    this.states.get(ii-2).getQuartet().value()+
-                    this.states.get(ii-3).getQuartet().value() != 2) {
+                if (this.states.get(ii-0).getPatternSync().value()+
+                    this.states.get(ii-1).getPatternSync().value()+
+                    this.states.get(ii-2).getPatternSync().value()+
+                    this.states.get(ii-3).getPatternSync().value() != 2) {
                     quartetErrors++;
                     if (debug>1) System.err.println("ERROR:  HelicitySequence QUARTET: "+ii);
                 }

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/HelicitySequenceDelayed.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/HelicitySequenceDelayed.java
@@ -1,12 +1,5 @@
 package org.jlab.detector.helicity;
 
-import org.jlab.io.base.DataEvent;
-import org.jlab.io.base.DataBank;
-import org.jlab.io.hipo.HipoDataSource;
-
-// this will allow access to tagged events:
-//import org.jlab.jnp.hipo4.io.HipoReader;
-
 /**
  *
  * Just adding a delay to HelicitySequence, where delay is the number
@@ -16,19 +9,23 @@ import org.jlab.io.hipo.HipoDataSource;
  */
 public class HelicitySequenceDelayed extends HelicitySequence {
   
-    private final int delay;
+    private int delay;
 
     public HelicitySequenceDelayed(int delay) {
         this.delay=delay;
     }
+
+    public void setDelay(int delay) {
+        this.delay=delay;
+    }
     
     @Override
-    public HelicityState get(int n) {
+    public HelicityBit get(int n) {
         return super.get(n+delay);
     }
     
     @Override
-    public HelicityState find(long timestamp) {
+    public HelicityBit find(long timestamp) {
         return this.get(super.findIndex(timestamp));
     }
 
@@ -44,72 +41,15 @@ public class HelicitySequenceDelayed extends HelicitySequence {
     
     @Override
     public void show() {
-        HelicityState prev=super.get(0);
+        HelicityState prev=super.getState(0);
         for (int ii=0; ii<this.size(); ii++) {
-            if (super.get(ii).getPatternSync()==HelicityBit.PLUS) continue;
+            if (super.getState(ii).getPatternSync()==HelicityBit.PLUS) continue;
             System.out.println(String.format("%4d %6s %6s %6s",
                     ii,
-                    super.get(ii).getInfo(prev,ii),
-                    super.get(ii).getHelicity(),
+                    super.getState(ii).getInfo(prev,ii),
+                    super.getState(ii).getHelicity(),
                     super.getPrediction(ii)));
-            prev=super.get(ii);
+            prev=super.getState(ii);
         }
-    }
-    
-    public static void main(String[] args) {
-
-        HelicitySequenceDelayed seq=new HelicitySequenceDelayed(8);
-
-        final String dir="/Users/baltzell/data/CLAS12/rg-b/decoded/";
-        final String file="clas_006432.evio.00041-00042.hipo";
-
-        HipoDataSource reader=new HipoDataSource();
-        reader.open(dir+file);
-
-        while (reader.hasEvent()) {
-            DataEvent event = reader.getNextEvent();
-            if (!event.hasBank("HEL::flip")) continue;
-            DataBank bank=event.getBank("HEL::flip");
-            HelicityState state=HelicityState.createFromFlipBank(bank);
-            seq.addState(state);
-        }
-
-        seq.show();
-
-        reader.close();
-        
-        HipoDataSource reader2=new HipoDataSource();
-        reader2.open(dir+file);
-        
-        // just use this to count unique flips to curtail printouts:
-        HelicitySequence seq2=new HelicitySequence();
-
-        int nevents=0;
-        int nflips=0;
-        while (reader2.hasEvent()) {
-            nevents++;
-            DataEvent event = reader2.getNextEvent();
-            if (!event.hasBank("RUN::config")) continue;
-            if (event.hasBank("HEL::flip")) {
-                if (seq2.addState(HelicityState.createFromFlipBank(event.getBank("HEL::flip")))) {
-                    nflips++;
-                }
-            }
-            if (nflips<310) continue;
-            if (nevents%100!=0) continue;
-            //if (nflips>200) break;
-            final long timestamp = event.getBank("RUN::config").getLong("timestamp",0);
-            //final byte l3 = event.getBank("RUN::config").getByte("helicityL3",0);
-            
-            final byte l3 = event.getBank("HEL::online").getByte("helicity",0);
-            
-            final byte predicted = seq.findPrediction(timestamp)==null ? -9 : seq.findPrediction(timestamp).value();
-            
-            final byte measured = seq.find(timestamp)==null ? -9 : seq.find(timestamp).getHelicity().value();
-            
-            System.out.println(String.format("%d %5d l3=%+d l4b=%+d l4c=%+d",
-                    timestamp,nflips,l3,predicted,measured));
-        }
-
     }
 }

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/HelicitySequenceDelayed.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/HelicitySequenceDelayed.java
@@ -46,7 +46,7 @@ public class HelicitySequenceDelayed extends HelicitySequence {
     public void show() {
         HelicityState prev=super.get(0);
         for (int ii=0; ii<this.size(); ii++) {
-            if (super.get(ii).getQuartet()==HelicityBit.PLUS) continue;
+            if (super.get(ii).getPatternSync()==HelicityBit.PLUS) continue;
             System.out.println(String.format("%4d %6s %6s %6s",
                     ii,
                     super.get(ii).getInfo(prev,ii),

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/HelicitySequenceDelayed.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/HelicitySequenceDelayed.java
@@ -99,11 +99,16 @@ public class HelicitySequenceDelayed extends HelicitySequence {
             if (nevents%100!=0) continue;
             //if (nflips>200) break;
             final long timestamp = event.getBank("RUN::config").getLong("timestamp",0);
-            final byte l3 = event.getBank("RUN::config").getByte("helicityL3",0);
-            final byte l4b = seq.findPrediction(timestamp)==null ? -9 : seq.findPrediction(timestamp).value();
-            final byte l4c = seq.find(timestamp)==null ? -9 : seq.find(timestamp).getHelicity().value();
+            //final byte l3 = event.getBank("RUN::config").getByte("helicityL3",0);
+            
+            final byte l3 = event.getBank("HEL::online").getByte("helicity",0);
+            
+            final byte predicted = seq.findPrediction(timestamp)==null ? -9 : seq.findPrediction(timestamp).value();
+            
+            final byte measured = seq.find(timestamp)==null ? -9 : seq.find(timestamp).getHelicity().value();
+            
             System.out.println(String.format("%d %5d l3=%+d l4b=%+d l4c=%+d",
-                    timestamp,nflips,l3,l4b,l4c));
+                    timestamp,nflips,l3,predicted,measured));
         }
 
     }

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/HelicityState.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/HelicityState.java
@@ -193,7 +193,7 @@ public class HelicityState {
     public long getTimestamp() { return this.timestamp; }
     public HelicityBit getHelicityRaw() { return this.helicityRaw; }
     public HelicityBit getHelicity() { return this.helicity; }
-    public HelicityBit getSync() { return this.pairSync; }
-    public HelicityBit getQuartet() { return this.patternSync; }
+    public HelicityBit getPairSync() { return this.pairSync; }
+    public HelicityBit getPatternSync() { return this.patternSync; }
 
 }


### PR DESCRIPTION
* accommodate HWP during analysis
* switch quartet/sync method names to the more proper patternSync/pairSync
* move analysis example to dedicated class
* switch public getters to all return HelicityBit instead of combo of State/Bit
* cleanup javadocs