### PR TITLE
Turn on REC::Particle sorting

### DIFF
--- a/common-tools/clas-reco/src/main/java/org/jlab/clas/detector/DetectorParticle.java
+++ b/common-tools/clas-reco/src/main/java/org/jlab/clas/detector/DetectorParticle.java
@@ -738,10 +738,9 @@ public class DetectorParticle implements Comparable {
         if(response==null) return -1.0;
         return this.getPathLength(response.getPosition());
     }  
-    
+   
+    @Override
     public int compareTo(Object o) {
-
-        System.err.println("DetectorParticle:  Not ready for sorting!!!!!!!!!!!!!!!");
 
         DetectorParticle other = (DetectorParticle) o;
 
@@ -754,10 +753,10 @@ public class DetectorParticle implements Comparable {
 
         // then charge ordering (-,+,0):
         else if (this.getCharge() != other.getCharge()) {
-            if      (this.getCharge()  > 0) return -1;
-            else if (other.getCharge() > 0) return  1;
-            else if (this.getCharge()  < 0) return -1;
+            if      (this.getCharge()  < 0) return -1;
             else if (other.getCharge() < 0) return  1;
+            else if (this.getCharge()  > 0) return -1;
+            else if (other.getCharge() > 0) return  1;
             else throw new RuntimeException("Impossible.");
         }
 

--- a/reconstruction/eb/src/main/java/org/jlab/service/eb/EBEngine.java
+++ b/reconstruction/eb/src/main/java/org/jlab/service/eb/EBEngine.java
@@ -1,5 +1,6 @@
 package org.jlab.service.eb;
 
+import java.util.Collections;
 import java.util.List;
 import org.jlab.clas.reco.ReconstructionEngine;
 import org.jlab.io.base.DataEvent;
@@ -131,7 +132,9 @@ public class EBEngine extends ReconstructionEngine {
 
         // create REC:detector banks:
         if(eb.getEvent().getParticles().size()>0){
-        
+       
+            Collections.sort(eb.getEvent().getParticles());
+
             eb.setParticleStatuses();
             //eb.setEventStatuses();
             


### PR DESCRIPTION
1. Trigger Particle
2. Negatives
3. Positives
4. Neutrals

And then momentum-ordered with groups 2/3/4.

RECFT::Particle still maintains the same row-ordering as REC::Particle.