### PR TITLE
Helicity analysis updates

### DIFF
--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/HelicityAnalysis.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/HelicityAnalysis.java
@@ -26,9 +26,8 @@ public class HelicityAnalysis {
      * @return  unanalyzed sequence
      */
     public static HelicitySequenceDelayed readSequence(List<String> filenames) {
-        
-        HelicitySequenceDelayed seq=new HelicitySequenceDelayed(0);
-        seq.setVerbosity(3);
+       
+        HelicitySequenceDelayed seq=new HelicitySequenceDelayed(8);
        
         for (String filename : filenames) {
 

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/HelicityAnalysisSimple.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/HelicityAnalysisSimple.java
@@ -1,0 +1,77 @@
+package org.jlab.detector.helicity;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.jlab.jnp.hipo4.data.Bank;
+import org.jlab.jnp.hipo4.data.Event;
+import org.jlab.jnp.hipo4.data.SchemaFactory;
+import org.jlab.jnp.hipo4.io.HipoReader;
+
+/**
+ *
+ * @author baltzell
+ */
+public class HelicityAnalysisSimple {
+
+    /**
+     * Example of accessing delay-corrected helicity.
+     *
+     * The 2 lines marked with "!!!" are specific to delay-corrected helicity.
+     * 
+     * @param args a list of input HIPO4 filenames 
+     */
+    public static void main(String[] args) {
+
+        final String dir="/Users/baltzell/data/CLAS12/rg-b/decoded/";
+        final String file="clas_006432.evio.00041-00042.hipo";
+        List<String> filenames=new ArrayList<>();
+
+        // override with user-inputs if available:
+        if (args.length>0) filenames.addAll(Arrays.asList(args));
+        else               filenames.add(dir+file);
+
+        // 1!!!1 initialize the helicity sequence:
+        HelicitySequenceDelayed seq = HelicityAnalysis.readSequence(filenames);
+        
+        seq.setVerbosity(1);
+
+        // now read the full events, e.g. during a normal physics analysis: 
+        
+        // loop over files:
+        for (String filename : filenames) {
+
+            // open the file, initialize reader/tags/schema:
+            HipoReader reader = new HipoReader();
+            reader.setTags(0);
+            reader.open(filename);
+            SchemaFactory schema = reader.getSchemaFactory();
+       
+            // loop over events:
+            while (reader.hasNext()) {
+              
+                // read the event:
+                Event event=new Event();
+                reader.nextEvent(event);
+               
+                // get the event's timestamp:
+                Bank rcfgBank=new Bank(schema.getSchema("RUN::config"));
+                event.read(rcfgBank);
+                if (rcfgBank.getRows()<=0) continue;
+                final int  evno = rcfgBank.getInt("event",0);
+                final long timestamp = rcfgBank.getLong("timestamp",0);
+               
+                // 2!!!2 use the timestamp to get the delay-corrected helicity:
+                HelicityBit predicted = seq.findPrediction(timestamp);
+
+                if (predicted==null || predicted==HelicityBit.UDF) {
+                    System.out.println(String.format("Bad Helicity: event=%d time=%d helicity=%s",evno,timestamp,predicted));
+                }
+                else {
+                    // proceed with physics analysis:
+                }
+            }
+            reader.close();
+        }
+    }
+}

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/HelicityGenerator.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/HelicityGenerator.java
@@ -2,6 +2,7 @@ package org.jlab.detector.helicity;
 
 import java.util.List;
 import java.util.ArrayList;
+import java.util.Collections;
 
 /**
  * Helicity Pseudo-Random Sequence.
@@ -27,7 +28,10 @@ public final class HelicityGenerator {
 
     public static final int REGISTER_SIZE=30;
     private final List<Integer> states=new ArrayList<>();
+    private int offset=0;
     private int register=0;
+    private long timestamp=0;
+    private int verbosity=0;
 
     public HelicityGenerator(){}
 
@@ -44,6 +48,14 @@ public final class HelicityGenerator {
         return nextBit;
     }
 
+    /**
+     * Get the timestamp of the first state in the generator sequence.
+     * @return timestamp (4ns)
+     */
+    public long getTimestamp() {
+        return timestamp;
+    }
+    
     /**
      * Shift the register with the next state.
      * Requires initialized()==false.
@@ -68,6 +80,7 @@ public final class HelicityGenerator {
     public void reset() {
         this.states.clear();
         this.register=0;
+        this.timestamp=-1;
     }
 
     /**
@@ -143,4 +156,168 @@ public final class HelicityGenerator {
         return this.states.get(n) == 0 ?
             HelicityBit.PLUS : HelicityBit.MINUS;
     }
+    
+   
+    /**
+     * Initialize with a list of states.
+     * 
+     * The states are first time-ordered, and error-checking is done to find the
+     * first valid sequence of sufficient length in the list and use it to
+     * initialize the generator, otherwise the return value will be false.
+     * @param states list of HelicityState objects
+     * @return success of initializing the generator 
+     */
+    public final boolean initialize(List<HelicityState> states) {
+
+        if (this.verbosity>0) {
+            System.out.println("HelicityGenerator:  Initializing with "+states.size()+" states ...");
+        }
+       
+        // make sure they're time-ordered:
+        Collections.sort(states);
+        
+        if (this.verbosity>10) {
+            for (HelicityState state : states) {
+                System.out.println(state);
+            }
+        }
+        
+        // reset this generator:
+        this.reset();
+      
+        // these will be the first valid sequence found in the input states:
+        List<Integer> iStates=new ArrayList<>();
+
+        for (int iState=0; iState<states.size(); iState++) {
+            
+            HelicityState thisState=states.get(iState);
+
+            // any initial state will do:
+            if (iStates.isEmpty()) {
+                if (this.verbosity>2) {
+                    System.out.println("HelicityGenerator:  got first state: "+thisState);
+                }
+                iStates.add(iState);
+            }
+
+            else {
+
+                HelicityState prevState = states.get(iStates.get(iStates.size()-1));
+            
+                // bad pair sync, reset the sequence:
+                if (thisState.getPairSync() == prevState.getPairSync()) {
+                    if (this.verbosity>1){
+                        System.out.println("HelicityGenerator:  got bad pair, resetting... "+prevState+" / "+thisState);
+                    }
+                    iStates.clear();
+                }
+
+                // bad pattern sync, reset the sequence:
+                // FIXME: we assume quartet here
+                else if (iStates.size() > 2 &&
+                        thisState.getPatternSync().value()+
+                        prevState.getPatternSync().value()+
+                        states.get(iStates.get(iStates.size()-2)).getPatternSync().value()+
+                        states.get(iStates.get(iStates.size()-3)).getPatternSync().value() != 2 ){
+                    if (this.verbosity>1){
+                        System.out.println("HelicityGenerator:  got bad pattern, resetting... "+thisState);
+                    }
+                    iStates.clear();
+                }
+           
+                else {
+
+                    // get time difference between states:
+                    final double seconds = (thisState.getTimestamp() -
+                            prevState.getTimestamp()) / HelicitySequence.TIMESTAMP_CLOCK;
+                
+                    // bad timestamp delta, reset the sequence:
+                    if (seconds < (1.0-0.5)/HelicitySequence.HELICITY_CLOCK ||
+                            seconds > (1.0+0.5)/HelicitySequence.HELICITY_CLOCK) {
+                        if (this.verbosity>1){
+                            System.out.println("HelicityGenerator:  got bad timestamp, resetting... ");
+                        }
+                        iStates.clear();
+                    }
+
+                    // passed all checks, add the state:
+                    else {
+                        iStates.add(iState);
+                    }
+           
+                    // we got enough states, stop looking for more:
+                    // FIXME: we assume quartet here
+                    if (iStates.size() >= REGISTER_SIZE*4+1) {
+                        break;
+                    }
+                }
+            }
+        }
+
+        // ok, we got enough to initialize the generator:
+        // FIXME: we assume quartet here
+        if (iStates.size() >= REGISTER_SIZE*4+1) {
+            
+            // this will be the index of the first state
+            this.offset = -1;
+
+            // store all states timestamps to apply a modulo correction
+            List <Double> timestamps = new ArrayList<>();
+            
+            for (int jj=0; jj<iStates.size(); jj++) {
+
+                HelicityState state=states.get(iStates.get(jj));
+
+                // we've got enough valid, consecutive states, so correct
+                // the first state's timestamp and stop the investigation:
+                if (this.initialized()) {
+                    this.timestamp=0;
+                    for (int kk=0; kk<timestamps.size(); kk++) {
+                        this.timestamp += timestamps.get(kk);
+                    }
+                    this.timestamp /= timestamps.size();
+                    if (this.verbosity>1) {
+                        System.out.println("HelicityGenerator:  modulo-corrected timestamp:  "+timestamps);
+                    }
+                    break;
+                }
+
+                // first state in the pattern, add it to the generator:
+                if (state.getPatternSync() == HelicityBit.MINUS) {
+                    if (this.size() == 0) {
+                        this.offset = jj;
+                    }
+                    this.addState(state);
+                }
+
+                // subtract off the nominal flip period:
+                if (this.size() > 0) {
+                    long timeStamp=state.getTimestamp();
+                    double corr=(jj-this.offset)/HelicitySequence.HELICITY_CLOCK*HelicitySequence.TIMESTAMP_CLOCK;
+                    timestamps.add(timeStamp-corr);
+                    if (this.verbosity>2) {
+                        System.out.println(this.verbosity);
+                        System.out.println(String.format("HelicityGenerator:  timestamp = %d/%.1f/%.2f",
+                                timeStamp,corr,timeStamp-corr));
+                    }
+                }
+            }
+        }
+
+        if (!this.initialized()) {
+            System.out.println("HelicityGenerator:  Initialization Error.");
+            this.reset();
+        }
+
+        return this.initialized();
+    }
+    
+    public void setVerbosity(int verbosity) {
+        this.verbosity=verbosity;
+    }
+
+    public int getOffset() {
+        return this.offset;
+    }
+    
 }

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/HelicityState.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/HelicityState.java
@@ -12,7 +12,7 @@ import org.jlab.io.base.DataBank;
  *
  * @author baltzell
  */
-public class HelicityState {
+public class HelicityState implements Comparable<HelicityState> {
 
     // FIXME:  these should go in CCDB
     private static final short HALFADC=2000;
@@ -39,6 +39,13 @@ public class HelicityState {
         else                     return HelicityBit.MINUS;
     }
 
+    @Override
+    public int compareTo(HelicityState other) {
+        if (this.getTimestamp() < other.getTimestamp()) return -1;
+        if (this.getTimestamp() > other.getTimestamp()) return +1;
+        return 0;
+    }
+    
     /**
      * Create a state from a HEL::adc org.jlab.jnp.hipo4.data.Bank
      * 


### PR DESCRIPTION
* add simpler example
* always toss first state change (with potentially erroneous timestamp)
* accommodate/reject gaps in initializing generator
* set default delay to 8