### PR TITLE
Add timestamp-based lookup of most recent tag=1 RUN::scaler bank

### DIFF
--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/DaqScalers.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/DaqScalers.java
@@ -41,15 +41,32 @@ public class DaqScalers {
     private float beamCharge=0;
     private float beamChargeGated=0;
     private float livetime=0;
+    private long timestamp   = 0;
     public Dsc2RawReading dsc2=null;
     public StruckRawReading struck=null;
+    public void setTimestamp(long timestamp) { this.timestamp=timestamp; }
     private void setBeamCharge(float q) { this.beamCharge=q; }
     private void setBeamChargeGated(float q) { this.beamChargeGated=q; }
     private void setLivetime(float l) { this.livetime=l; }
     public float getBeamCharge() { return beamCharge; }
     public float getBeamChargeGated() { return beamChargeGated; }
     public float getLivetime()   { return livetime; }
+    public long getTimestamp() { return timestamp; }
     public void show() { System.out.println("BCG=%.3f   LT=%.3f"); }
+
+    /**
+    * @param runScalerBank HIPO RUN::scaler bank
+    */
+    public static DaqScalers create(Bank runScalerBank) {
+        DaqScalers ds=new DaqScalers();
+        for (int ii=0; ii<runScalerBank.getRows(); ii++) {
+            ds.livetime=runScalerBank.getFloat("livetime", ii);
+            ds.beamCharge=runScalerBank.getFloat("fcup",ii);
+            ds.beamChargeGated=runScalerBank.getFloat("fcupgated",ii);
+            break; 
+        }
+        return ds;
+    }
 
     /**
     * @param rawScalerBank HIPO RAW::scaler bank
@@ -86,17 +103,6 @@ public class DaqScalers {
             return ds;
         }
         return null;
-    }
-
-    public static DaqScalers create(Bank runScalerBank) {
-        DaqScalers ds=new DaqScalers();
-        for (int ii=0; ii<runScalerBank.getRows(); ii++) {
-            ds.livetime=runScalerBank.getFloat("livetime", ii);
-            ds.beamCharge=runScalerBank.getFloat("fcup",ii);
-            ds.beamChargeGated=runScalerBank.getFloat("fcupgated",ii);
-            break; 
-        }
-        return ds;
     }
 
     /**

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/DaqScalersSequence.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/DaqScalersSequence.java
@@ -1,0 +1,184 @@
+package org.jlab.detector.decode;
+
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+
+import org.jlab.jnp.hipo4.io.HipoReader;
+import org.jlab.jnp.hipo4.data.Event;
+import org.jlab.jnp.hipo4.data.Bank;
+import org.jlab.jnp.hipo4.data.SchemaFactory;
+
+/**
+ * For easy access to most recent scaler readout for any given event.
+ *
+ * See the main() method for example use case, where only the 2 lines
+ * marked with "!!!" are specific to accessing scalers.
+ * 
+ * @author baltzell
+ */
+public class DaqScalersSequence implements Comparator<DaqScalers> {
+   
+    private final List<DaqScalers> scalers=new ArrayList<>();
+   
+    @Override
+    public int compare(DaqScalers o1, DaqScalers o2) {
+        if (o1.getTimestamp() < o2.getTimestamp()) return -1;
+        if (o1.getTimestamp() > o2.getTimestamp()) return +1;
+        return 0;
+    }
+   
+    private int findIndex(long timestamp) {
+        if (this.scalers.isEmpty()) return -1;
+        if (timestamp < this.scalers.get(0).getTimestamp()) return -1;
+        if (timestamp > this.scalers.get(this.scalers.size()-1).getTimestamp()) return -1;
+        // make a fake state for timestamp search:
+        DaqScalers ds=new DaqScalers();
+        ds.setTimestamp(timestamp);
+        final int index=Collections.binarySearch(this.scalers,ds,new DaqScalersSequence());
+        final int n = index<0 ? -index-2 : index;
+        return n;
+    }
+   
+    protected boolean add(DaqScalers ds) {
+        if (this.scalers.isEmpty()) {
+            this.scalers.add(ds);
+            return true;
+        }
+        else {
+            final int index=Collections.binarySearch(this.scalers,ds,new DaqScalersSequence());
+            if (index==this.scalers.size()) {
+                // its timestamp is later than the existing sequence:
+                this.scalers.add(ds);
+                return true;
+            }
+            else if (index<0) {
+                // it's a unique timestamp, insert it:
+                this.scalers.add(-index-1,ds);
+                return true;
+            }
+            else {
+                // it's a duplicate timestamp, ignore it:
+                return false;
+            }
+        }
+    }
+    
+    /**
+     * @param timestamp TI timestamp (i.e. RUN::config.timestamp)
+     * @return the most recent DaqScalers for the given timestamp
+     */
+    public DaqScalers get(long timestamp) {
+        final int n=this.findIndex(timestamp);
+        if (n>=0) return this.scalers.get(n);
+        return null;
+    }
+   
+    /**
+     * This reads tag=1 events for RUN::scaler banks, and initializes and returns
+     * a {@link DaqScalersSequence} that can be used to access the most recent scaler
+     * readout for any given event.
+     * 
+     * @param filenames list of names of HIPO files to read
+     * @return  sequence
+     */
+    public static DaqScalersSequence readSequence(List<String> filenames) {
+       
+        DaqScalersSequence seq=new DaqScalersSequence();
+
+        for (String filename : filenames) {
+
+            HipoReader reader = new HipoReader();
+            reader.setTags(1);
+            reader.open(filename);
+        
+            SchemaFactory schema = reader.getSchemaFactory();
+        
+            while (reader.hasNext()) {
+            
+                Event event=new Event();
+                Bank scalerBank=new Bank(schema.getSchema("RUN::scaler"));
+                Bank configBank=new Bank(schema.getSchema("RUN::config"));
+            
+                reader.nextEvent(event);
+                event.read(scalerBank);
+                event.read(configBank);
+         
+                long timestamp=0;
+                
+                if (scalerBank.getRows()<1) continue;
+                if (configBank.getRows()>0) {
+                    timestamp=configBank.getLong("timestamp",0);
+                }
+        
+                DaqScalers ds=DaqScalers.create(scalerBank);
+                ds.setTimestamp(timestamp);
+                seq.add(ds);
+            }
+
+            reader.close();
+        }
+        
+        return seq;
+    }
+    
+    public static void main(String[] args) {
+        
+        final String dir="/Users/baltzell/data/CLAS12/rg-a/decoded/6b.2.0/";
+        final String file="clas_005038.evio.00000-00004.hipo";
+        //final String dir="/Users/baltzell/data/CLAS12/rg-b/decoded/";
+        //final String file="clas_006432.evio.00041-00042.hipo";
+
+        List<String> filenames=new ArrayList<>();
+        if (args.length>0) filenames.addAll(Arrays.asList(args));
+        else               filenames.add(dir+file);
+
+        // 1!!!1 initialize a sequence from tag=1 events: 
+        DaqScalersSequence seq = DaqScalersSequence.readSequence(filenames);
+
+        long good=0;
+        long bad=0;
+        
+        for (String filename : filenames) {
+
+            HipoReader reader = new HipoReader();
+            reader.setTags(0);
+            reader.open(filename);
+            
+            SchemaFactory schema = reader.getSchemaFactory();
+        
+            while (reader.hasNext()) {
+
+                Bank rcfgBank=new Bank(schema.getSchema("RUN::config"));
+               
+                Event event=new Event();
+                reader.nextEvent(event);
+              
+                event.read(rcfgBank);
+            
+                long timestamp = -1;
+                if (rcfgBank.getRows()>0) 
+                    timestamp = rcfgBank.getLong("timestamp",0);
+
+                // 2!!!2 use the timestamp to get the most recent scaler data:
+                DaqScalers ds=seq.get(timestamp);
+
+                if (ds==null) {
+                    bad++;
+                }
+                else {
+                    good++;
+                    // do something useful with beam charge here:
+                }
+            }
+
+            System.out.println("DaqScalersSequence:  bad/good/badPercent: "
+                    +bad+" "+good+" "+100*((float)bad)/(bad+good)+"%");
+
+            reader.close();
+
+        }
+    }
+}


### PR DESCRIPTION
For easy access to pseudo-event-based beam charge for RG-A post-processing.