### PR TITLE
travis upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,12 @@ sudo: required
 language: java
 
 jdk:
-  - oraclejdk9
+  - openjdk11
 
-# this affects which java version is used:
 addons:
   apt:
     packages:
-      - oracle-java9-installer
+      - openjfx
 
 before_install:
     - ls -lthra

--- a/common-tools/clas-geometry/pom.xml
+++ b/common-tools/clas-geometry/pom.xml
@@ -28,6 +28,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.openjfx</groupId>
+      <artifactId>javafx-controls</artifactId>
+      <version>11</version>
+    </dependency>
+    <dependency>
       <groupId>org.jlab.ccdb</groupId>
       <artifactId>ccdb</artifactId>
       <version>1.2</version>

--- a/common-tools/clas-io/pom.xml
+++ b/common-tools/clas-io/pom.xml
@@ -29,6 +29,12 @@
   <dependencies>
 
     <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <version>2.3.0</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.jlab.coda</groupId>
       <artifactId>jevio</artifactId>
       <version>6.1-SNAPSHOT</version>

--- a/common-tools/clas-jcsg/pom.xml
+++ b/common-tools/clas-jcsg/pom.xml
@@ -28,6 +28,16 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.openjfx</groupId>
+      <artifactId>javafx-controls</artifactId>
+      <version>11</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openjfx</groupId>
+      <artifactId>javafx-fxml</artifactId>
+      <version>11</version>
+    </dependency>
+    <dependency>
       <groupId>org.jlab.clas</groupId>
       <artifactId>clas-geometry</artifactId>
       <version>6.3.1-SNAPSHOT</version>

--- a/common-tools/cnuphys/bCNU/pom.xml
+++ b/common-tools/cnuphys/bCNU/pom.xml
@@ -16,48 +16,65 @@
 
   <dependencies>
 
+    <dependency>
+      <groupId>org.openjfx</groupId>
+      <artifactId>javafx-controls</artifactId>
+      <version>11</version>
+    </dependency>
 
-<dependency>
-    <groupId>cnuphys</groupId>
-    <artifactId>numRec</artifactId>
-    <version>1.0</version>
-  </dependency>
+    <dependency>
+      <groupId>org.openjfx</groupId>
+      <artifactId>javafx-swing</artifactId>
+      <version>11</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.openjfx</groupId>
+      <artifactId>javafx-controls</artifactId>
+      <version>11</version>
+    </dependency>
+
+    <dependency>
+      <groupId>cnuphys</groupId>
+      <artifactId>numRec</artifactId>
+      <version>1.0</version>
+    </dependency>
   
     <dependency>
-        <groupId>cnuphys</groupId>
-        <artifactId>splot</artifactId>
-        <version>2.0-SNAPSHOT</version>
+      <groupId>cnuphys</groupId>
+      <artifactId>splot</artifactId>
+      <version>2.0-SNAPSHOT</version>
     </dependency>
 
     <dependency>
-        <groupId>cnuphys</groupId>
-        <artifactId>magfield</artifactId>
-        <version>2.0-SNAPSHOT</version>
+      <groupId>cnuphys</groupId>
+      <artifactId>magfield</artifactId>
+      <version>2.0-SNAPSHOT</version>
     </dependency>
  
- <dependency>
-        <groupId>cnuphys</groupId>
-        <artifactId>swimmer</artifactId>
-        <version>2.0-SNAPSHOT</version>
+    <dependency>
+      <groupId>cnuphys</groupId>
+      <artifactId>swimmer</artifactId>
+      <version>2.0-SNAPSHOT</version>
     </dependency>
 
-  <dependency>
-        <groupId>org.jlab.coda</groupId>
-        <artifactId>cMsg</artifactId>
-        <version>3.3</version>
+    <dependency>
+      <groupId>org.jlab.coda</groupId>
+      <artifactId>cMsg</artifactId>
+      <version>3.3</version>
     </dependency>
 
-<dependency>
-        <groupId>org.jlab.coda</groupId>
-        <artifactId>et</artifactId>
-        <version>14.0</version>
-      </dependency>
+    <dependency>
+      <groupId>org.jlab.coda</groupId>
+      <artifactId>et</artifactId>
+      <version>14.0</version>
+    </dependency>
 
- </dependencies>
+  </dependencies>
 
-    <properties>
-      <maven.compiler.target>1.8</maven.compiler.target>
-      <maven.compiler.source>1.8</maven.compiler.source>
-    </properties>
+  <properties>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+  </properties>
     
 </project>

--- a/common-tools/cnuphys/parent/pom.xml
+++ b/common-tools/cnuphys/parent/pom.xml
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs</artifactId>
-      <version>3.1.0</version>
+      <version>3.1.12</version>
     </dependency>
   </dependencies>
 
@@ -38,7 +38,7 @@
       <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
-        <version>3.1.0-RC6</version>
+        <version>3.1.12</version>
         <configuration>
           <excludeFilterFile>spotbugs-exclude.xml</excludeFilterFile>
         </configuration>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs</artifactId>
-      <version>3.1.0</version>
+      <version>3.1.12</version>
     </dependency>
   </dependencies>
 
@@ -68,7 +68,7 @@
       <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
-        <version>3.1.0-RC6</version>
+        <version>3.1.12</version>
         <configuration>
           <excludeFilterFile>spotbugs-exclude.xml</excludeFilterFile>
         </configuration>


### PR DESCRIPTION
Update our travis build configuration to be compatible with ubuntu 16/xenial
* in the last couple weeks our new branches appear to now be automatically selecting xenial in travis (and failing), while our main branch (development) is still running 14/trusty (and succeeding), although we do not specify an ubuntu version in our travis config
* this is presumably consistent with travis's move to xenial and dropping support for trusty: https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment, and so we should follow suit and get compatible with xenial
* this requires:
  * upgrading to a jdk version 10/11 and maven to 1.6 to use stock 16/xenial packages
    * this pull request chooses openjdk11
  * updating our pom.xmls
    * explicitly including dependencies that were previously in the jdk but now external as of 11
    * i.e. javafx and javax
  * moving to a more modern spotbugs version, and this pull request chooses 3.1.12

Note, the pom.xml changes should be backward compatible with java 8.

