### PR TITLE
Revert "reduce memory limit on recon-util (10% faster!?)"

### DIFF
--- a/bin/recon-util
+++ b/bin/recon-util
@@ -4,4 +4,4 @@ source `dirname $0`/env.sh
 
 MALLOC_ARENA_MAX=1; export MALLOC_ARENA_MAX
 
-java -Xmx1024m -Xms768m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*:$CLAS12DIR/lib/utils/*" org.jlab.clas.reco.EngineProcessor $*
+java -Xmx1536m -Xms1024m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*:$CLAS12DIR/lib/utils/*" org.jlab.clas.reco.EngineProcessor $*


### PR DESCRIPTION
This reverts commit f060779cf55834536900551677e7fe8f039042ca.

Looks like performance testing was with java 11 ...