### PR TITLE
remove bashisms from /bin/sh scripts (plus cleanup)

### DIFF
--- a/bin/bos2hipo
+++ b/bin/bos2hipo
@@ -1,5 +1,5 @@
-#!/bin/sh -f
+#!/bin/sh
 
-source `dirname $0`/env.sh 
+. `dirname $0`/env.sh 
 
 java -Xms1024m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/plugins/*" org.jlab.io.utils.Bos2HipoEventBank $*

--- a/bin/daqEventViewer
+++ b/bin/daqEventViewer
@@ -1,5 +1,5 @@
-#!/bin/sh -f
+#!/bin/sh
 
-source `dirname $0`/env.sh 
+. `dirname $0`/env.sh 
 
 java -Xms1024m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*:$CLAS12DIR/lib/utils/*" org.jlab.detector.examples.RawEventViewer $*

--- a/bin/dclayereffs-ana
+++ b/bin/dclayereffs-ana
@@ -1,5 +1,5 @@
-#!/bin/sh -f
+#!/bin/sh
 
-source `dirname $0`/env.sh 
+. `dirname $0`/env.sh 
 
 java -Dsun.java2d.pmoffscreen=false -Xmx2048m -Xms1024m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/utils/*:$CLAS12DIR/lib/services/*" org.jlab.service.dc.LayerEfficiencyAnalyzer $*

--- a/bin/decoder
+++ b/bin/decoder
@@ -1,9 +1,8 @@
-#!/bin/bash
+#!/bin/sh
 
-# This doesn't work in dash (Travis's /bin/sh):
-source `dirname $0`/env.sh 
+. `dirname $0`/env.sh 
 
-MALLOC_ARENA_MAX=1; export MALLOC_ARENA_MAX
+export MALLOC_ARENA_MAX=1
 
 echo +-------------------------------------------------------------------------
 echo "| DECODER GENERATION 4 (using HIPO-4 Library)"

--- a/bin/dict-maker
+++ b/bin/dict-maker
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/bin/sh
 
-source `dirname $0`/env.sh 
+. `dirname $0`/env.sh 
 
-MALLOC_ARENA_MAX=1; export MALLOC_ARENA_MAX
+export MALLOC_ARENA_MAX=1
 
 java -Xmx1536m -Xms1024m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*:$CLAS12DIR/lib/utils/*" org.jlab.service.dc.TrackDictionaryMakerRNG $*

--- a/bin/dict-merge
+++ b/bin/dict-merge
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/bin/sh
 
-source `dirname $0`/env.sh 
+. `dirname $0`/env.sh 
 
-MALLOC_ARENA_MAX=1; export MALLOC_ARENA_MAX
+export MALLOC_ARENA_MAX=1
 
 java -Xmx1536m -Xms1024m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*:$CLAS12DIR/lib/utils/*" org.jlab.service.dc.TrackDictionaryMerger $*

--- a/bin/dict-validate
+++ b/bin/dict-validate
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/bin/sh
 
-source `dirname $0`/env.sh 
+. `dirname $0`/env.sh 
 
-MALLOC_ARENA_MAX=1; export MALLOC_ARENA_MAX
+export MALLOC_ARENA_MAX=1
 
 java -Xmx1536m -Xms1024m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*:$CLAS12DIR/lib/utils/*" org.jlab.service.dc.TrackDictionaryValidation $*

--- a/bin/env.sh
+++ b/bin/env.sh
@@ -1,7 +1,6 @@
-#!/bin/bash
+#!/bin/sh
 
-SCRIPT_DIR=`dirname $0`
-CLAS12DIR=$SCRIPT_DIR/../ ; export CLAS12DIR
+export CLAS12DIR=`dirname $0`/..
 
 # Set default field maps (but do not override user's env):
 if [ -z "$COAT_MAGFIELD_TORUSMAP" ]; then

--- a/bin/evio-viewer
+++ b/bin/evio-viewer
@@ -1,5 +1,5 @@
-#!/bin/sh -f
+#!/bin/sh
 
-source `dirname $0`/env.sh 
+. `dirname $0`/env.sh 
 
 java -cp "$CLAS12DIR/lib/clas/*" org.jlab.coda.eventViewer.EventTreeFrame $*

--- a/bin/evio2hipo
+++ b/bin/evio2hipo
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/bin/sh
 
-source `dirname $0`/env.sh 
+. `dirname $0`/env.sh 
 
-MALLOC_ARENA_MAX=1; export MALLOC_ARENA_MAX
+export MALLOC_ARENA_MAX=1
 
 java -Xmx1536m -Xms1024m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/plugins/*" org.jlab.clas.reco.io.EvioHipoEvent4 $*

--- a/bin/eviocure
+++ b/bin/eviocure
@@ -1,7 +1,7 @@
-#!/bin/sh -f
+#!/bin/sh
 
-source `dirname $0`/env.sh 
+. `dirname $0`/env.sh 
 
-MALLOC_ARENA_MAX=1; export MALLOC_ARENA_MAX
+export MALLOC_ARENA_MAX=1
 
 java -Xmx1536m -Xms1024m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/plugins/*" org.jlab.io.utils.EvioCure $*

--- a/bin/eviodump
+++ b/bin/eviodump
@@ -1,5 +1,5 @@
-#!/bin/sh -f
+#!/bin/sh
 
-source `dirname $0`/env.sh 
+. `dirname $0`/env.sh 
 
 java -Xms1024m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/plugins/*" org.jlab.io.utils.DataSourceDump $*

--- a/bin/hadd
+++ b/bin/hadd
@@ -1,5 +1,5 @@
-#!/bin/sh -f
+#!/bin/sh
 
-source `dirname $0`/env.sh 
+. `dirname $0`/env.sh 
 
 java -Xms1024m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/plugins/*" org.jlab.groot.data.TDirectory $*

--- a/bin/hipo-browser
+++ b/bin/hipo-browser
@@ -1,5 +1,5 @@
-#!/bin/sh -f
+#!/bin/sh
 
-source `dirname $0`/env.sh 
+. `dirname $0`/env.sh 
 
 java -Xms1024m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/plugins/*" org.jlab.groot.ui.TBrowser $*

--- a/bin/hipo-utils
+++ b/bin/hipo-utils
@@ -1,7 +1,7 @@
-#!/bin/sh -f
+#!/bin/sh
 
-source `dirname $0`/env.sh 
+. `dirname $0`/env.sh 
 
-MALLOC_ARENA_MAX=1; export MALLOC_ARENA_MAX
+export MALLOC_ARENA_MAX=1
 
 java -Xmx2048m -Xms1024m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/plugins/*" org.jlab.jnp.hipo4.utils.HipoUtilities $*

--- a/bin/kpp-plots
+++ b/bin/kpp-plots
@@ -1,5 +1,5 @@
-#!/bin/sh -f
+#!/bin/sh
 
-source `dirname $0`/env.sh 
+. `dirname $0`/env.sh 
 
 java -Dsun.java2d.pmoffscreen=false -Xmx2048m -Xms1024m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/utils/*:$CLAS12DIR/lib/services/*" org.clas.viewer.KPPViewer $*

--- a/bin/mon12
+++ b/bin/mon12
@@ -1,5 +1,5 @@
-#!/bin/sh -f
+#!/bin/sh
 
-source `dirname $0`/env.sh 
+. `dirname $0`/env.sh 
 
 java -Dsun.java2d.pmoffscreen=false -Xmx2048m -Xms1024m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/utils/*:$CLAS12DIR/lib/services/*" org.clas.viewer.EventViewer $*

--- a/bin/postprocess
+++ b/bin/postprocess
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/bin/sh
 
-source `dirname $0`/env.sh 
+. `dirname $0`/env.sh 
 
-MALLOC_ARENA_MAX=1; export MALLOC_ARENA_MAX
+export MALLOC_ARENA_MAX=1
 
 java -Xmx768m -Xms768m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*:$CLAS12DIR/lib/utils/*" org.jlab.analysis.postprocess.Tag1ToEvent $*

--- a/bin/rebuild-scalers
+++ b/bin/rebuild-scalers
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/bin/sh
 
-source `dirname $0`/env.sh 
+. `dirname $0`/env.sh 
 
-MALLOC_ARENA_MAX=1; export MALLOC_ARENA_MAX
+export MALLOC_ARENA_MAX=1
 
 java -Xmx768m -Xms768m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*:$CLAS12DIR/lib/utils/*" org.jlab.analysis.postprocess.RebuildScalers $*

--- a/bin/recon-util
+++ b/bin/recon-util
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/bin/sh
 
-source `dirname $0`/env.sh 
+. `dirname $0`/env.sh 
 
-MALLOC_ARENA_MAX=1; export MALLOC_ARENA_MAX
+export MALLOC_ARENA_MAX=1
 
 java -Xmx1536m -Xms1024m -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*:$CLAS12DIR/lib/utils/*" org.jlab.clas.reco.EngineProcessor $*

--- a/bin/run-groovy
+++ b/bin/run-groovy
@@ -1,16 +1,9 @@
-#!/bin/bash
+#!/bin/sh
 
-source `dirname $0`/env.sh 
+. `dirname $0`/env.sh 
 
-CLARA_HOME=`dirname $0`/..
-CLAS12DIR=`dirname $0`/..
-CLAS12DIR=`dirname $0`/.. ; export CLAS12DIR
+export CLAS12DIR=`dirname $0`/..
  
-CLARA_SERVICES=$CLAS12DIR/lib/services ; export CLARA_SERVICES
-
-#JYTHONPATH=${CLAS12DIR}/lib/jython
-#echo ${JYTHONPATH}
-
 #--------------------------------------------------------------
 # Adding supporting COAT jar files
 for i in `ls -a $CLAS12DIR/lib/clas/*.jar`
@@ -56,5 +49,5 @@ echo "*    Version : 3a  Release : 2016       *"
 echo "*****************************************"
 echo " "
 echo " "
-JAVA_OPTS="-Dsun.java2d.pmoffscreen=false -Xms1024m -Xmx2048m"; export JAVA_OPTS
+export JAVA_OPTS="-Dsun.java2d.pmoffscreen=false -Xms1024m -Xmx2048m"
 groovy -cp "$JYPATH" $*


### PR DESCRIPTION
Ubuntu comes with /bin/sh pointing to dash, which doesn't support bash's "source".  (Could also switch all /bin/sh scripts to explicitly /bin/bash, not sure which is better.)