### PR TITLE
Iss551 ecal hit and cluster ids

### DIFF
--- a/etc/bankdefs/hipo4/ecal.json
+++ b/etc/bankdefs/hipo4/ecal.json
@@ -5,14 +5,15 @@
     "item" : 21,
     "info": "ECAL hits",
     "entries": [
-       {"name":"id",       "type":"S", "info":"id of the hit"},
-       {"name":"status",   "type":"S", "info":"status of the hit"},
-       {"name":"sector",   "type":"B",  "info":"sector of ECAL"},
-       {"name":"layer",    "type":"B",  "info":"Layer of ECAL (1-3:PCAL, 4-6:ECIN, 7-9:ECOUT"},
-       {"name":"strip",    "type":"B",  "info":"Strip number"},
-       {"name":"peakid",   "type":"B",  "info":"Peak id"},
-       {"name":"energy",   "type":"F", "info":"Energy of the hit"},
-       {"name":"time",     "type":"F", "info":"Time of the hit"}
+       {"name":"id",         "type":"S",  "info":"id of the hit"},
+       {"name":"clusterId",  "type":"S",  "info":"id of cluster the hit eblongs to"},
+       {"name":"status",     "type":"S",  "info":"status of the hit"},
+       {"name":"sector",     "type":"B",  "info":"sector of ECAL"},
+       {"name":"layer",      "type":"B",  "info":"Layer of ECAL (1-3:PCAL, 4-6:ECIN, 7-9:ECOUT"},
+       {"name":"strip",      "type":"B",  "info":"Strip number"},
+       {"name":"peakid",     "type":"B",  "info":"Peak id"},
+       {"name":"energy",     "type":"F",  "info":"Energy of the hit"},
+       {"name":"time",       "type":"F",  "info":"Time of the hit"}
     ]
   },
   {

--- a/etc/bankdefs/hipo4/ecal.json
+++ b/etc/bankdefs/hipo4/ecal.json
@@ -6,7 +6,7 @@
     "info": "ECAL hits",
     "entries": [
        {"name":"id",         "type":"S",  "info":"id of the hit"},
-       {"name":"clusterId",  "type":"S",  "info":"id of cluster the hit eblongs to"},
+       {"name":"clusterId",  "type":"S",  "info":"id of the cluster the hit belongs to"},
        {"name":"status",     "type":"S",  "info":"status of the hit"},
        {"name":"sector",     "type":"B",  "info":"sector of ECAL"},
        {"name":"layer",      "type":"B",  "info":"Layer of ECAL (1-3:PCAL, 4-6:ECIN, 7-9:ECOUT"},

--- a/reconstruction/ec/src/main/java/org/jlab/service/ec/ECCommon.java
+++ b/reconstruction/ec/src/main/java/org/jlab/service/ec/ECCommon.java
@@ -380,7 +380,21 @@ public class ECCommon {
             clusters.get(i).setEnergy(
             clusters.get(i).getEnergy(0) + 
             clusters.get(i).getEnergy(1) +
-            clusters.get(i).getEnergy(2));      
+            clusters.get(i).getEnergy(2));
+            
+            // As clusters are already defined at this point, we can fill the clusterID of ECStrips belonging to the given cluster
+            // === U strips ===
+            for( ECStrip curStrip : clusters.get(i).getPeak(0).getStrips() ){
+                curStrip.setClusterId(i+1);
+            }
+            // === V strips ===
+            for( ECStrip curStrip : clusters.get(i).getPeak(1).getStrips() ){
+                curStrip.setClusterId(i+1);
+            }
+            // === W strips ===
+            for( ECStrip curStrip : clusters.get(i).getPeak(2).getStrips() ){
+                curStrip.setClusterId(i+1);
+            }
         }  
         
         return clusters;

--- a/reconstruction/ec/src/main/java/org/jlab/service/ec/ECCommon.java
+++ b/reconstruction/ec/src/main/java/org/jlab/service/ec/ECCommon.java
@@ -381,20 +381,6 @@ public class ECCommon {
             clusters.get(i).getEnergy(0) + 
             clusters.get(i).getEnergy(1) +
             clusters.get(i).getEnergy(2));
-            
-            // As clusters are already defined at this point, we can fill the clusterID of ECStrips belonging to the given cluster
-            // === U strips ===
-            for( ECStrip curStrip : clusters.get(i).getPeak(0).getStrips() ){
-                curStrip.setClusterId(i+1);
-            }
-            // === V strips ===
-            for( ECStrip curStrip : clusters.get(i).getPeak(1).getStrips() ){
-                curStrip.setClusterId(i+1);
-            }
-            // === W strips ===
-            for( ECStrip curStrip : clusters.get(i).getPeak(2).getStrips() ){
-                curStrip.setClusterId(i+1);
-            }
         }  
         
         return clusters;

--- a/reconstruction/ec/src/main/java/org/jlab/service/ec/ECCommon.java
+++ b/reconstruction/ec/src/main/java/org/jlab/service/ec/ECCommon.java
@@ -225,6 +225,7 @@ public class ECCommon {
                 
                 strip.setADC(adc);
                 strip.setTriggerPhase(triggerPhase);
+                strip.setID(i+1);
                 
                 double sca = (is==5)?AtoE5[ind[il-1]]:AtoE[ind[il-1]]; 
                 if (variation=="clas6") sca = 1.0;               

--- a/reconstruction/ec/src/main/java/org/jlab/service/ec/ECEngine.java
+++ b/reconstruction/ec/src/main/java/org/jlab/service/ec/ECEngine.java
@@ -49,8 +49,8 @@ public class ECEngine extends ReconstructionEngine {
             }
         }
                 
-        List<ECStrip>     ecStrips = ECCommon.initEC(de,  ecDetector, this.getConstantsManager(), runNo); // thresholds, ADC/TDC match        
-        List<ECPeak>      ecPeaks  = ECCommon.processPeaks(ECCommon.createPeaks(ecStrips)); // thresholds, split peaks -> update peak-lines          
+        List<ECStrip>     ecStrips = ECCommon.initEC(de,  ecDetector, this.getConstantsManager(), runNo); // thresholds, ADC/TDC match
+        List<ECPeak>      ecPeaks  = ECCommon.processPeaks(ECCommon.createPeaks(ecStrips)); // thresholds, split peaks -> update peak-lines
         List<ECCluster> ecClusters = new ArrayList<ECCluster>();
         ecClusters.addAll(ECCommon.createClusters(ecPeaks,1)); //PCAL
         ecClusters.addAll(ECCommon.createClusters(ecPeaks,4)); //ECinner 
@@ -98,13 +98,22 @@ public class ECEngine extends ReconstructionEngine {
 	    
         DataBank bankS = de.createBank("ECAL::hits", strips.size());
         for(int h = 0; h < strips.size(); h++){
-            bankS.setByte("sector",  h,  (byte) strips.get(h).getDescriptor().getSector());
-            bankS.setByte("layer",   h,  (byte) strips.get(h).getDescriptor().getLayer());
-            bankS.setByte("strip",   h,  (byte) strips.get(h).getDescriptor().getComponent());
-            bankS.setByte("peakid",  h,  (byte) strips.get(h).getPeakId());
-            bankS.setShort("id",     h, (short) strips.get(h).getID());
-            bankS.setFloat("energy", h, (float) strips.get(h).getEnergy());
-            bankS.setFloat("time",   h, (float) strips.get(h).getTime());
+            bankS.setByte("sector",     h,  (byte) strips.get(h).getDescriptor().getSector());
+            bankS.setByte("layer",      h,  (byte) strips.get(h).getDescriptor().getLayer());
+            bankS.setByte("strip",      h,  (byte) strips.get(h).getDescriptor().getComponent());
+            bankS.setByte("peakid",     h,  (byte) strips.get(h).getPeakId());
+            bankS.setShort("id",        h, (short) strips.get(h).getID());
+            //System.out.println("clusterID = " + strips.get(h).getClusterId());
+            //bankS.setShort("clusterid", h, (short) strips.get(h).getClusterId() );
+            bankS.setShort("clusterId", h, (short) 5 );
+            bankS.setFloat("energy",    h, (float) strips.get(h).getEnergy());
+            bankS.setFloat("time",      h, (float) strips.get(h).getTime());
+            
+            System.out.println("ColumnList is: " );
+            
+            for( String cur_col: bankS.getColumnList()  ){
+                System.out.println(cur_col);
+            }
         }
        
         DataBank  bankP =  de.createBank("ECAL::peaks", peaks.size());
@@ -139,7 +148,6 @@ public class ECEngine extends ReconstructionEngine {
             bankC.setInt("coordU",   c,         clusters.get(c).getPeak(0).getCoord());
             bankC.setInt("coordV",   c,         clusters.get(c).getPeak(1).getCoord());
             bankC.setInt("coordW",   c,         clusters.get(c).getPeak(2).getCoord());
-  
         }
      
         DataBank bankM = de.createBank("ECAL::moments", clusters.size());

--- a/reconstruction/ec/src/main/java/org/jlab/service/ec/ECEngine.java
+++ b/reconstruction/ec/src/main/java/org/jlab/service/ec/ECEngine.java
@@ -19,222 +19,245 @@ import org.jlab.io.base.DataEvent;
  * @author gavalian
  */
 public class ECEngine extends ReconstructionEngine {
-    
-    Detector              ecDetector = null;
-    public Boolean             debug = false;
-    public Boolean  isSingleThreaded = false;
-    public Boolean       singleEvent = false;
-    public Boolean              isMC = false;
-    int                       calrun = 2;
-    
-    public ECEngine(){
-        super("EC","gavalian","1.0");
+
+    Detector ecDetector = null;
+    public Boolean debug = false;
+    public Boolean isSingleThreaded = false;
+    public Boolean singleEvent = false;
+    public Boolean isMC = false;
+    int calrun = 2;
+
+    public ECEngine() {
+        super("EC", "gavalian", "1.0");
     }
-    
+
     @Override
     public boolean processDataEvent(DataEvent de) {
-           
+
         ECCommon.setDebug(debug);
         ECCommon.setisSingleThreaded(isSingleThreaded);
         ECCommon.setSingleEvent(singleEvent);
 
         int runNo = 10;
-        
-        if(de.hasBank("RUN::config")==true){
+
+        if (de.hasBank("RUN::config") == true) {
             DataBank bank = de.getBank("RUN::config");
             runNo = bank.getInt("run", 0);
-            if (runNo<=0) {
+            if (runNo <= 0) {
                 System.err.println("ECEngine:  got run <= 0 in RUN::config, skipping event.");
                 return false;
             }
         }
-                
-        List<ECStrip>     ecStrips = ECCommon.initEC(de,  ecDetector, this.getConstantsManager(), runNo); // thresholds, ADC/TDC match
-        List<ECPeak>      ecPeaks  = ECCommon.processPeaks(ECCommon.createPeaks(ecStrips)); // thresholds, split peaks -> update peak-lines
+
+        List<ECStrip> ecStrips = ECCommon.initEC(de, ecDetector, this.getConstantsManager(), runNo); // thresholds, ADC/TDC match
+        List<ECPeak> ecPeaks = ECCommon.processPeaks(ECCommon.createPeaks(ecStrips)); // thresholds, split peaks -> update peak-lines
         List<ECCluster> ecClusters = new ArrayList<ECCluster>();
-        ecClusters.addAll(ECCommon.createClusters(ecPeaks,1)); //PCAL
-        ecClusters.addAll(ECCommon.createClusters(ecPeaks,4)); //ECinner 
-        ecClusters.addAll(ECCommon.createClusters(ecPeaks,7)); //ECouter
-        
+        ecClusters.addAll(ECCommon.createClusters(ecPeaks, 1)); //PCAL
+        ecClusters.addAll(ECCommon.createClusters(ecPeaks, 4)); //ECinner 
+        ecClusters.addAll(ECCommon.createClusters(ecPeaks, 7)); //ECouter
+
         ECCommon.shareClustersEnergy(ecClusters);  // Repair 2 clusters which share the same peaks
-       
-        if (debug) {
-            System.out.println(" STRIPS SIZE = " + ecStrips.size());
-            for(ECStrip strip : ecStrips) System.out.println(strip);
-            System.out.println(" PEAKS  SIZE = " + ecPeaks.size());
-            for(ECPeak p : ecPeaks) System.out.println(p);
-            System.out.println("\n\n\n\n\nEC CLUSTERS SIZE = " + ecClusters.size());
-            if(ecClusters.size()==2) {for(ECCluster c : ecClusters) System.out.println(c);}
-        }
-	    
-        this.writeHipoBanks(de,ecStrips,ecPeaks,ecClusters);  
-        
-        if (isSingleThreaded) {
-        	ECCommon.clearMyStructures();
-        	getStrips().addAll(ecStrips);
-        	getPeaks().addAll(ecPeaks);
-        	getClusters().addAll(ecClusters);
-        }
-        
-        return true;
-    }
-    
-    public List<ECStrip> getStrips() {
-	    return ECCommon.getMyStrips();    		
-    }
-    
-    public List<ECPeak> getPeaks() {
-	    return ECCommon.getMyPeaks();    
-    }
-    
-    public List<ECCluster> getClusters() {
-	    return ECCommon.getMyClusters();    
-    }    
-        
-    private void writeHipoBanks(DataEvent de, 
-                                List<ECStrip>   strips, 
-                                List<ECPeak>    peaks, 
-                                List<ECCluster> clusters){
-	    
-        DataBank bankS = de.createBank("ECAL::hits", strips.size());
-        for(int h = 0; h < strips.size(); h++){
-            bankS.setByte("sector",     h,  (byte) strips.get(h).getDescriptor().getSector());
-            bankS.setByte("layer",      h,  (byte) strips.get(h).getDescriptor().getLayer());
-            bankS.setByte("strip",      h,  (byte) strips.get(h).getDescriptor().getComponent());
-            bankS.setByte("peakid",     h,  (byte) strips.get(h).getPeakId());
-            bankS.setShort("id",        h, (short) strips.get(h).getID());
-            //System.out.println("clusterID = " + strips.get(h).getClusterId());
-            //bankS.setShort("clusterid", h, (short) strips.get(h).getClusterId() );
-            bankS.setShort("clusterId", h, (short) 5 );
-            bankS.setFloat("energy",    h, (float) strips.get(h).getEnergy());
-            bankS.setFloat("time",      h, (float) strips.get(h).getTime());
-            
-            System.out.println("ColumnList is: " );
-            
-            for( String cur_col: bankS.getColumnList()  ){
-                System.out.println(cur_col);
+
+        for (int iCl = 0; iCl < ecClusters.size(); iCl++) {
+            // As clusters are already defined at this point, we can fill the clusterID of ECStrips belonging to the given cluster
+            // === U strips ===
+            for (ECStrip curStrip : ecClusters.get(iCl).getPeak(0).getStrips()) {
+                curStrip.setClusterId(iCl + 1);
+            }
+            // === V strips ===
+            for (ECStrip curStrip : ecClusters.get(iCl).getPeak(1).getStrips()) {
+                curStrip.setClusterId(iCl + 1);
+            }
+            // === W strips ===
+            for (ECStrip curStrip : ecClusters.get(iCl).getPeak(2).getStrips()) {
+                curStrip.setClusterId(iCl + 1);
             }
         }
-       
-        DataBank  bankP =  de.createBank("ECAL::peaks", peaks.size());
-        for(int p = 0; p < peaks.size(); p++){
-            bankP.setByte("sector",  p,  (byte) peaks.get(p).getDescriptor().getSector());
-            bankP.setByte("layer",   p,  (byte) peaks.get(p).getDescriptor().getLayer());
-            bankP.setFloat("xo",     p, (float) peaks.get(p).getLine().origin().x());
-            bankP.setFloat("yo",     p, (float) peaks.get(p).getLine().origin().y());
-            bankP.setFloat("zo",     p, (float) peaks.get(p).getLine().origin().z());
-            bankP.setFloat("xe",     p, (float) peaks.get(p).getLine().end().x());
-            bankP.setFloat("ye",     p, (float) peaks.get(p).getLine().end().y());
-            bankP.setFloat("ze",     p, (float) peaks.get(p).getLine().end().z());
-            bankP.setFloat("energy", p, (float) peaks.get(p).getEnergy());
-            bankP.setFloat("time",   p, (float) peaks.get(p).getTime());
-        }   
-        
-        DataBank bankC = de.createBank("ECAL::clusters", clusters.size());        
-        for(int c = 0; c < clusters.size(); c++){
-            bankC.setByte("sector",  c,  (byte) clusters.get(c).clusterPeaks.get(0).getDescriptor().getSector());
-            bankC.setByte("layer",   c,  (byte) clusters.get(c).clusterPeaks.get(0).getDescriptor().getLayer());
-            bankC.setFloat("energy", c, (float) clusters.get(c).getEnergy());
-            bankC.setFloat("time",   c, (float) clusters.get(c).getRawADCTime());
-            bankC.setByte("idU",     c,  (byte) clusters.get(c).UVIEW_ID);
-            bankC.setByte("idV",     c,  (byte) clusters.get(c).VVIEW_ID);
-            bankC.setByte("idW",     c,  (byte) clusters.get(c).WVIEW_ID);
-            bankC.setFloat("x",      c, (float) clusters.get(c).getHitPosition().x());
-            bankC.setFloat("y",      c, (float) clusters.get(c).getHitPosition().y());
-            bankC.setFloat("z",      c, (float) clusters.get(c).getHitPosition().z());
-            bankC.setFloat("widthU", c,         clusters.get(c).getPeak(0).getMultiplicity());
-            bankC.setFloat("widthV", c,         clusters.get(c).getPeak(1).getMultiplicity());
-            bankC.setFloat("widthW", c,         clusters.get(c).getPeak(2).getMultiplicity());
-            bankC.setInt("coordU",   c,         clusters.get(c).getPeak(0).getCoord());
-            bankC.setInt("coordV",   c,         clusters.get(c).getPeak(1).getCoord());
-            bankC.setInt("coordW",   c,         clusters.get(c).getPeak(2).getCoord());
+
+        if (debug) {
+            System.out.println(" STRIPS SIZE = " + ecStrips.size());
+            for (ECStrip strip : ecStrips) {
+                System.out.println(strip);
+            }
+            System.out.println(" PEAKS  SIZE = " + ecPeaks.size());
+            for (ECPeak p : ecPeaks) {
+                System.out.println(p);
+            }
+            System.out.println("\n\n\n\n\nEC CLUSTERS SIZE = " + ecClusters.size());
+            if (ecClusters.size() == 2) {
+                for (ECCluster c : ecClusters) {
+                    System.out.println(c);
+                }
+            }
         }
-     
+
+        this.writeHipoBanks(de, ecStrips, ecPeaks, ecClusters);
+
+        if (isSingleThreaded) {
+            ECCommon.clearMyStructures();
+            getStrips().addAll(ecStrips);
+            getPeaks().addAll(ecPeaks);
+            getClusters().addAll(ecClusters);
+        }
+
+        return true;
+    }
+
+    public List<ECStrip> getStrips() {
+        return ECCommon.getMyStrips();
+    }
+
+    public List<ECPeak> getPeaks() {
+        return ECCommon.getMyPeaks();
+    }
+
+    public List<ECCluster> getClusters() {
+        return ECCommon.getMyClusters();
+    }
+
+    private void writeHipoBanks(DataEvent de,
+            List<ECStrip> strips,
+            List<ECPeak> peaks,
+            List<ECCluster> clusters) {
+
+        DataBank bankS = de.createBank("ECAL::hits", strips.size());
+        for (int h = 0; h < strips.size(); h++) {
+            bankS.setByte("sector", h, (byte) strips.get(h).getDescriptor().getSector());
+            bankS.setByte("layer", h, (byte) strips.get(h).getDescriptor().getLayer());
+            bankS.setByte("strip", h, (byte) strips.get(h).getDescriptor().getComponent());
+            bankS.setByte("peakid", h, (byte) strips.get(h).getPeakId());
+            bankS.setShort("id", h, (short) strips.get(h).getID());
+            //System.out.println("clusterID = " + strips.get(h).getClusterId());
+            bankS.setShort("clusterId", h, (short) strips.get(h).getClusterId());
+            //bankS.setShort("clusterId", h, (short) 5 );
+            bankS.setFloat("energy", h, (float) strips.get(h).getEnergy());
+            bankS.setFloat("time", h, (float) strips.get(h).getTime());
+
+            //System.out.println("ColumnList is: " );
+//            for( String cur_col: bankS.getColumnList()  ){
+//                System.out.println(cur_col);
+//            }
+        }
+
+        DataBank bankP = de.createBank("ECAL::peaks", peaks.size());
+        for (int p = 0; p < peaks.size(); p++) {
+            bankP.setByte("sector", p, (byte) peaks.get(p).getDescriptor().getSector());
+            bankP.setByte("layer", p, (byte) peaks.get(p).getDescriptor().getLayer());
+            bankP.setFloat("xo", p, (float) peaks.get(p).getLine().origin().x());
+            bankP.setFloat("yo", p, (float) peaks.get(p).getLine().origin().y());
+            bankP.setFloat("zo", p, (float) peaks.get(p).getLine().origin().z());
+            bankP.setFloat("xe", p, (float) peaks.get(p).getLine().end().x());
+            bankP.setFloat("ye", p, (float) peaks.get(p).getLine().end().y());
+            bankP.setFloat("ze", p, (float) peaks.get(p).getLine().end().z());
+            bankP.setFloat("energy", p, (float) peaks.get(p).getEnergy());
+            bankP.setFloat("time", p, (float) peaks.get(p).getTime());
+        }
+
+        DataBank bankC = de.createBank("ECAL::clusters", clusters.size());
+        for (int c = 0; c < clusters.size(); c++) {
+            bankC.setByte("sector", c, (byte) clusters.get(c).clusterPeaks.get(0).getDescriptor().getSector());
+            bankC.setByte("layer", c, (byte) clusters.get(c).clusterPeaks.get(0).getDescriptor().getLayer());
+            bankC.setFloat("energy", c, (float) clusters.get(c).getEnergy());
+            bankC.setFloat("time", c, (float) clusters.get(c).getRawADCTime());
+            bankC.setByte("idU", c, (byte) clusters.get(c).UVIEW_ID);
+            bankC.setByte("idV", c, (byte) clusters.get(c).VVIEW_ID);
+            bankC.setByte("idW", c, (byte) clusters.get(c).WVIEW_ID);
+            bankC.setFloat("x", c, (float) clusters.get(c).getHitPosition().x());
+            bankC.setFloat("y", c, (float) clusters.get(c).getHitPosition().y());
+            bankC.setFloat("z", c, (float) clusters.get(c).getHitPosition().z());
+            bankC.setFloat("widthU", c, clusters.get(c).getPeak(0).getMultiplicity());
+            bankC.setFloat("widthV", c, clusters.get(c).getPeak(1).getMultiplicity());
+            bankC.setFloat("widthW", c, clusters.get(c).getPeak(2).getMultiplicity());
+            bankC.setInt("coordU", c, clusters.get(c).getPeak(0).getCoord());
+            bankC.setInt("coordV", c, clusters.get(c).getPeak(1).getCoord());
+            bankC.setInt("coordW", c, clusters.get(c).getPeak(2).getCoord());
+        }
+
         DataBank bankM = de.createBank("ECAL::moments", clusters.size());
-        for(int c = 0; c < clusters.size(); c++){
+        for (int c = 0; c < clusters.size(); c++) {
             bankM.setFloat("distU", c, (float) clusters.get(c).clusterPeaks.get(0).getDistanceEdge());
             bankM.setFloat("distV", c, (float) clusters.get(c).clusterPeaks.get(1).getDistanceEdge());
             bankM.setFloat("distW", c, (float) clusters.get(c).clusterPeaks.get(2).getDistanceEdge());
-            bankM.setFloat("m1u", c,   (float) clusters.get(c).clusterPeaks.get(0).getMoment());
-            bankM.setFloat("m1v", c,   (float) clusters.get(c).clusterPeaks.get(1).getMoment());
-            bankM.setFloat("m1w", c,   (float) clusters.get(c).clusterPeaks.get(2).getMoment());
-            bankM.setFloat("m2u", c,   (float) clusters.get(c).clusterPeaks.get(0).getMoment2());
-            bankM.setFloat("m2v", c,   (float) clusters.get(c).clusterPeaks.get(1).getMoment2());
-            bankM.setFloat("m2w", c,   (float) clusters.get(c).clusterPeaks.get(2).getMoment2());
-            bankM.setFloat("m3u", c,   (float) clusters.get(c).clusterPeaks.get(0).getMoment3());
-            bankM.setFloat("m3v", c,   (float) clusters.get(c).clusterPeaks.get(1).getMoment3());
-            bankM.setFloat("m3w", c,   (float) clusters.get(c).clusterPeaks.get(2).getMoment3());
+            bankM.setFloat("m1u", c, (float) clusters.get(c).clusterPeaks.get(0).getMoment());
+            bankM.setFloat("m1v", c, (float) clusters.get(c).clusterPeaks.get(1).getMoment());
+            bankM.setFloat("m1w", c, (float) clusters.get(c).clusterPeaks.get(2).getMoment());
+            bankM.setFloat("m2u", c, (float) clusters.get(c).clusterPeaks.get(0).getMoment2());
+            bankM.setFloat("m2v", c, (float) clusters.get(c).clusterPeaks.get(1).getMoment2());
+            bankM.setFloat("m2w", c, (float) clusters.get(c).clusterPeaks.get(2).getMoment2());
+            bankM.setFloat("m3u", c, (float) clusters.get(c).clusterPeaks.get(0).getMoment3());
+            bankM.setFloat("m3v", c, (float) clusters.get(c).clusterPeaks.get(1).getMoment3());
+            bankM.setFloat("m3w", c, (float) clusters.get(c).clusterPeaks.get(2).getMoment3());
         }
-                
-        DataBank  bankD =  de.createBank("ECAL::calib", clusters.size());
-         for(int c = 0; c < clusters.size(); c++){
-            bankD.setByte("sector",  c,  (byte) clusters.get(c).clusterPeaks.get(0).getDescriptor().getSector());
-            bankD.setByte("layer",   c,  (byte) clusters.get(c).clusterPeaks.get(0).getDescriptor().getLayer());
+
+        DataBank bankD = de.createBank("ECAL::calib", clusters.size());
+        for (int c = 0; c < clusters.size(); c++) {
+            bankD.setByte("sector", c, (byte) clusters.get(c).clusterPeaks.get(0).getDescriptor().getSector());
+            bankD.setByte("layer", c, (byte) clusters.get(c).clusterPeaks.get(0).getDescriptor().getLayer());
             bankD.setFloat("energy", c, (float) clusters.get(c).getEnergy());
-            bankD.setFloat("rawEU",  c, (float) clusters.get(c).getRawEnergy(0));
-            bankD.setFloat("rawEV",  c, (float) clusters.get(c).getRawEnergy(1));
-            bankD.setFloat("rawEW",  c, (float) clusters.get(c).getRawEnergy(2));
-            bankD.setFloat("recEU",  c, (float) clusters.get(c).getEnergy(0));
-            bankD.setFloat("recEV",  c, (float) clusters.get(c).getEnergy(1));
-            bankD.setFloat("recEW",  c, (float) clusters.get(c).getEnergy(2));            
+            bankD.setFloat("rawEU", c, (float) clusters.get(c).getRawEnergy(0));
+            bankD.setFloat("rawEV", c, (float) clusters.get(c).getRawEnergy(1));
+            bankD.setFloat("rawEW", c, (float) clusters.get(c).getRawEnergy(2));
+            bankD.setFloat("recEU", c, (float) clusters.get(c).getEnergy(0));
+            bankD.setFloat("recEV", c, (float) clusters.get(c).getEnergy(1));
+            bankD.setFloat("recEW", c, (float) clusters.get(c).getEnergy(2));
         }
-         
-         de.appendBanks(bankS,bankP,bankC,bankD,bankM);
+
+        de.appendBanks(bankS, bankP, bankC, bankD, bankM);
 //         de.appendBanks(bankS,bankP,bankC,bankD);
 
     }
-   
+
     public void setCalRun(int runno) {
-        System.out.println("ECEngine: Calibration Run Number = "+runno);
+        System.out.println("ECEngine: Calibration Run Number = " + runno);
         this.calrun = runno;
     }
-    
+
     public void setVariation(String variation) {
-        System.out.println("ECEngine: Variation = "+variation);
+        System.out.println("ECEngine: Variation = " + variation);
         ECCommon.variation = variation;
-    } 
-    
+    }
+
     public void setVeff(float veff) {
-        System.out.println("ECEngine: Veff = "+veff);
-    	    ECCommon.veff = veff;
+        System.out.println("ECEngine: Veff = " + veff);
+        ECCommon.veff = veff;
     }
-    
+
     public void setNewTimeCal(boolean val) {
-        System.out.println("ECEngine: useNewTimeCal = "+val);
-    	ECCommon.useNewTimeCal = val;
+        System.out.println("ECEngine: useNewTimeCal = " + val);
+        ECCommon.useNewTimeCal = val;
     }
-    
+
     public void setStripThresholds(int thr0, int thr1, int thr2) {
-        System.out.println("ECEngine: Strip ADC thresholds = "+thr0+" "+thr1+" "+thr2);
+        System.out.println("ECEngine: Strip ADC thresholds = " + thr0 + " " + thr1 + " " + thr2);
         ECCommon.stripThreshold[0] = thr0;
         ECCommon.stripThreshold[1] = thr1;
         ECCommon.stripThreshold[2] = thr2;
     }
-    
+
     public void setPeakThresholds(int thr0, int thr1, int thr2) {
-        System.out.println("ECEngine: Peak ADC thresholds = "+thr0+" "+thr1+" "+thr2);
+        System.out.println("ECEngine: Peak ADC thresholds = " + thr0 + " " + thr1 + " " + thr2);
         ECCommon.peakThreshold[0] = thr0;
         ECCommon.peakThreshold[1] = thr1;
         ECCommon.peakThreshold[2] = thr2;
-    }   
-    
+    }
+
     public void setClusterCuts(float err0, float err1, float err2) {
-        System.out.println("ECEngine: Cluster Dalitz Cuts = "+err0+" "+err1+" "+err2);
+        System.out.println("ECEngine: Cluster Dalitz Cuts = " + err0 + " " + err1 + " " + err2);
         ECCommon.clusterError[0] = err0;
         ECCommon.clusterError[1] = err1;
         ECCommon.clusterError[2] = err2;
     }
-    
-    public DetectorCollection<H1F>  getHist() {
+
+    public DetectorCollection<H1F> getHist() {
         return ECCommon.H1_ecEng;
     }
-    
+
     @Override
     public boolean init() {
-    	
-        String[]  ecTables = new String[]{
-            "/calibration/ec/attenuation", 
-            "/calibration/ec/gain", 
+
+        String[] ecTables = new String[]{
+            "/calibration/ec/attenuation",
+            "/calibration/ec/gain",
             "/calibration/ec/timing",
             "/calibration/ec/time_jitter",
             "/calibration/ec/fadc_offset",
@@ -246,20 +269,21 @@ public class ECEngine extends ReconstructionEngine {
             "/calibration/ec/tmf_offset",
             "/calibration/ec/tmf_window"
         };
-        
-        
+
         requireConstants(Arrays.asList(ecTables));
         getConstantsManager().setVariation(ECCommon.variation);
         String variationName = Optional.ofNullable(this.getEngineConfigString("variation")).orElse("default");
-        ecDetector =  GeometryFactory.getDetector(DetectorType.ECAL,11,variationName);
+        ecDetector = GeometryFactory.getDetector(DetectorType.ECAL, 11, variationName);
 
         setCalRun(2);
-        setStripThresholds(10,9,8);
-        setPeakThresholds(18,20,15);
-        setClusterCuts(7,15,20);
-        
-        if (isSingleThreaded) ECCommon.initHistos();
+        setStripThresholds(10, 9, 8);
+        setPeakThresholds(18, 20, 15);
+        setClusterCuts(7, 15, 20);
+
+        if (isSingleThreaded) {
+            ECCommon.initHistos();
+        }
         return true;
     }
-    
+
 }

--- a/reconstruction/ec/src/main/java/org/jlab/service/ec/ECEngine.java
+++ b/reconstruction/ec/src/main/java/org/jlab/service/ec/ECEngine.java
@@ -19,45 +19,45 @@ import org.jlab.io.base.DataEvent;
  * @author gavalian
  */
 public class ECEngine extends ReconstructionEngine {
-
-    Detector ecDetector = null;
-    public Boolean debug = false;
-    public Boolean isSingleThreaded = false;
-    public Boolean singleEvent = false;
-    public Boolean isMC = false;
-    int calrun = 2;
-
-    public ECEngine() {
-        super("EC", "gavalian", "1.0");
+    
+    Detector              ecDetector = null;
+    public Boolean             debug = false;
+    public Boolean  isSingleThreaded = false;
+    public Boolean       singleEvent = false;
+    public Boolean              isMC = false;
+    int                       calrun = 2;
+    
+    public ECEngine(){
+        super("EC","gavalian","1.0");
     }
-
+    
     @Override
     public boolean processDataEvent(DataEvent de) {
-
+           
         ECCommon.setDebug(debug);
         ECCommon.setisSingleThreaded(isSingleThreaded);
         ECCommon.setSingleEvent(singleEvent);
 
         int runNo = 10;
-
-        if (de.hasBank("RUN::config") == true) {
+        
+        if(de.hasBank("RUN::config")==true){
             DataBank bank = de.getBank("RUN::config");
             runNo = bank.getInt("run", 0);
-            if (runNo <= 0) {
+            if (runNo<=0) {
                 System.err.println("ECEngine:  got run <= 0 in RUN::config, skipping event.");
                 return false;
             }
         }
-
-        List<ECStrip> ecStrips = ECCommon.initEC(de, ecDetector, this.getConstantsManager(), runNo); // thresholds, ADC/TDC match
-        List<ECPeak> ecPeaks = ECCommon.processPeaks(ECCommon.createPeaks(ecStrips)); // thresholds, split peaks -> update peak-lines
+                
+        List<ECStrip>     ecStrips = ECCommon.initEC(de,  ecDetector, this.getConstantsManager(), runNo); // thresholds, ADC/TDC match        
+        List<ECPeak>      ecPeaks  = ECCommon.processPeaks(ECCommon.createPeaks(ecStrips)); // thresholds, split peaks -> update peak-lines          
         List<ECCluster> ecClusters = new ArrayList<ECCluster>();
-        ecClusters.addAll(ECCommon.createClusters(ecPeaks, 1)); //PCAL
-        ecClusters.addAll(ECCommon.createClusters(ecPeaks, 4)); //ECinner 
-        ecClusters.addAll(ECCommon.createClusters(ecPeaks, 7)); //ECouter
-
+        ecClusters.addAll(ECCommon.createClusters(ecPeaks,1)); //PCAL
+        ecClusters.addAll(ECCommon.createClusters(ecPeaks,4)); //ECinner 
+        ecClusters.addAll(ECCommon.createClusters(ecPeaks,7)); //ECouter
+        
         ECCommon.shareClustersEnergy(ecClusters);  // Repair 2 clusters which share the same peaks
-
+       
         for (int iCl = 0; iCl < ecClusters.size(); iCl++) {
             // As clusters are already defined at this point, we can fill the clusterID of ECStrips belonging to the given cluster
             // === U strips ===
@@ -73,191 +73,178 @@ public class ECEngine extends ReconstructionEngine {
                 curStrip.setClusterId(iCl + 1);
             }
         }
-
+        
+        
         if (debug) {
             System.out.println(" STRIPS SIZE = " + ecStrips.size());
-            for (ECStrip strip : ecStrips) {
-                System.out.println(strip);
-            }
+            for(ECStrip strip : ecStrips) System.out.println(strip);
             System.out.println(" PEAKS  SIZE = " + ecPeaks.size());
-            for (ECPeak p : ecPeaks) {
-                System.out.println(p);
-            }
+            for(ECPeak p : ecPeaks) System.out.println(p);
             System.out.println("\n\n\n\n\nEC CLUSTERS SIZE = " + ecClusters.size());
-            if (ecClusters.size() == 2) {
-                for (ECCluster c : ecClusters) {
-                    System.out.println(c);
-                }
-            }
+            if(ecClusters.size()==2) {for(ECCluster c : ecClusters) System.out.println(c);}
         }
-
-        this.writeHipoBanks(de, ecStrips, ecPeaks, ecClusters);
-
+	    
+        this.writeHipoBanks(de,ecStrips,ecPeaks,ecClusters);  
+        
         if (isSingleThreaded) {
-            ECCommon.clearMyStructures();
-            getStrips().addAll(ecStrips);
-            getPeaks().addAll(ecPeaks);
-            getClusters().addAll(ecClusters);
+        	ECCommon.clearMyStructures();
+        	getStrips().addAll(ecStrips);
+        	getPeaks().addAll(ecPeaks);
+        	getClusters().addAll(ecClusters);
         }
-
+        
         return true;
     }
-
+    
     public List<ECStrip> getStrips() {
-        return ECCommon.getMyStrips();
+	    return ECCommon.getMyStrips();    		
     }
-
+    
     public List<ECPeak> getPeaks() {
-        return ECCommon.getMyPeaks();
+	    return ECCommon.getMyPeaks();    
     }
-
+    
     public List<ECCluster> getClusters() {
-        return ECCommon.getMyClusters();
-    }
-
-    private void writeHipoBanks(DataEvent de,
-            List<ECStrip> strips,
-            List<ECPeak> peaks,
-            List<ECCluster> clusters) {
-
+	    return ECCommon.getMyClusters();    
+    }    
+        
+    private void writeHipoBanks(DataEvent de, 
+                                List<ECStrip>   strips, 
+                                List<ECPeak>    peaks, 
+                                List<ECCluster> clusters){
+	    
         DataBank bankS = de.createBank("ECAL::hits", strips.size());
-        for (int h = 0; h < strips.size(); h++) {
-            bankS.setByte("sector", h, (byte) strips.get(h).getDescriptor().getSector());
-            bankS.setByte("layer", h, (byte) strips.get(h).getDescriptor().getLayer());
-            bankS.setByte("strip", h, (byte) strips.get(h).getDescriptor().getComponent());
-            bankS.setByte("peakid", h, (byte) strips.get(h).getPeakId());
+        for(int h = 0; h < strips.size(); h++){
+            bankS.setByte("sector",  h,  (byte) strips.get(h).getDescriptor().getSector());
+            bankS.setByte("layer",   h,  (byte) strips.get(h).getDescriptor().getLayer());
+            bankS.setByte("strip",   h,  (byte) strips.get(h).getDescriptor().getComponent());
+            bankS.setByte("peakid",  h,  (byte) strips.get(h).getPeakId());
             bankS.setShort("id", h, (short) strips.get(h).getID());
-            //System.out.println("clusterID = " + strips.get(h).getClusterId());
             bankS.setShort("clusterId", h, (short) strips.get(h).getClusterId());
-            //bankS.setShort("clusterId", h, (short) 5 );
             bankS.setFloat("energy", h, (float) strips.get(h).getEnergy());
-            bankS.setFloat("time", h, (float) strips.get(h).getTime());
-
-            //System.out.println("ColumnList is: " );
-//            for( String cur_col: bankS.getColumnList()  ){
-//                System.out.println(cur_col);
-//            }
+            bankS.setFloat("time",   h, (float) strips.get(h).getTime());                
         }
-
-        DataBank bankP = de.createBank("ECAL::peaks", peaks.size());
-        for (int p = 0; p < peaks.size(); p++) {
-            bankP.setByte("sector", p, (byte) peaks.get(p).getDescriptor().getSector());
-            bankP.setByte("layer", p, (byte) peaks.get(p).getDescriptor().getLayer());
-            bankP.setFloat("xo", p, (float) peaks.get(p).getLine().origin().x());
-            bankP.setFloat("yo", p, (float) peaks.get(p).getLine().origin().y());
-            bankP.setFloat("zo", p, (float) peaks.get(p).getLine().origin().z());
-            bankP.setFloat("xe", p, (float) peaks.get(p).getLine().end().x());
-            bankP.setFloat("ye", p, (float) peaks.get(p).getLine().end().y());
-            bankP.setFloat("ze", p, (float) peaks.get(p).getLine().end().z());
+       
+        DataBank  bankP =  de.createBank("ECAL::peaks", peaks.size());
+        for(int p = 0; p < peaks.size(); p++){
+            bankP.setByte("sector",  p,  (byte) peaks.get(p).getDescriptor().getSector());
+            bankP.setByte("layer",   p,  (byte) peaks.get(p).getDescriptor().getLayer());
+            bankP.setFloat("xo",     p, (float) peaks.get(p).getLine().origin().x());
+            bankP.setFloat("yo",     p, (float) peaks.get(p).getLine().origin().y());
+            bankP.setFloat("zo",     p, (float) peaks.get(p).getLine().origin().z());
+            bankP.setFloat("xe",     p, (float) peaks.get(p).getLine().end().x());
+            bankP.setFloat("ye",     p, (float) peaks.get(p).getLine().end().y());
+            bankP.setFloat("ze",     p, (float) peaks.get(p).getLine().end().z());
             bankP.setFloat("energy", p, (float) peaks.get(p).getEnergy());
-            bankP.setFloat("time", p, (float) peaks.get(p).getTime());
-        }
-
-        DataBank bankC = de.createBank("ECAL::clusters", clusters.size());
-        for (int c = 0; c < clusters.size(); c++) {
-            bankC.setByte("sector", c, (byte) clusters.get(c).clusterPeaks.get(0).getDescriptor().getSector());
-            bankC.setByte("layer", c, (byte) clusters.get(c).clusterPeaks.get(0).getDescriptor().getLayer());
+            bankP.setFloat("time",   p, (float) peaks.get(p).getTime());
+        }   
+        
+        DataBank bankC = de.createBank("ECAL::clusters", clusters.size());        
+        for(int c = 0; c < clusters.size(); c++){
+            bankC.setByte("sector",  c,  (byte) clusters.get(c).clusterPeaks.get(0).getDescriptor().getSector());
+            bankC.setByte("layer",   c,  (byte) clusters.get(c).clusterPeaks.get(0).getDescriptor().getLayer());
             bankC.setFloat("energy", c, (float) clusters.get(c).getEnergy());
-            bankC.setFloat("time", c, (float) clusters.get(c).getRawADCTime());
-            bankC.setByte("idU", c, (byte) clusters.get(c).UVIEW_ID);
-            bankC.setByte("idV", c, (byte) clusters.get(c).VVIEW_ID);
-            bankC.setByte("idW", c, (byte) clusters.get(c).WVIEW_ID);
-            bankC.setFloat("x", c, (float) clusters.get(c).getHitPosition().x());
-            bankC.setFloat("y", c, (float) clusters.get(c).getHitPosition().y());
-            bankC.setFloat("z", c, (float) clusters.get(c).getHitPosition().z());
-            bankC.setFloat("widthU", c, clusters.get(c).getPeak(0).getMultiplicity());
-            bankC.setFloat("widthV", c, clusters.get(c).getPeak(1).getMultiplicity());
-            bankC.setFloat("widthW", c, clusters.get(c).getPeak(2).getMultiplicity());
-            bankC.setInt("coordU", c, clusters.get(c).getPeak(0).getCoord());
-            bankC.setInt("coordV", c, clusters.get(c).getPeak(1).getCoord());
-            bankC.setInt("coordW", c, clusters.get(c).getPeak(2).getCoord());
+            bankC.setFloat("time",   c, (float) clusters.get(c).getRawADCTime());
+            bankC.setByte("idU",     c,  (byte) clusters.get(c).UVIEW_ID);
+            bankC.setByte("idV",     c,  (byte) clusters.get(c).VVIEW_ID);
+            bankC.setByte("idW",     c,  (byte) clusters.get(c).WVIEW_ID);
+            bankC.setFloat("x",      c, (float) clusters.get(c).getHitPosition().x());
+            bankC.setFloat("y",      c, (float) clusters.get(c).getHitPosition().y());
+            bankC.setFloat("z",      c, (float) clusters.get(c).getHitPosition().z());
+            bankC.setFloat("widthU", c,         clusters.get(c).getPeak(0).getMultiplicity());
+            bankC.setFloat("widthV", c,         clusters.get(c).getPeak(1).getMultiplicity());
+            bankC.setFloat("widthW", c,         clusters.get(c).getPeak(2).getMultiplicity());
+            bankC.setInt("coordU",   c,         clusters.get(c).getPeak(0).getCoord());
+            bankC.setInt("coordV",   c,         clusters.get(c).getPeak(1).getCoord());
+            bankC.setInt("coordW",   c,         clusters.get(c).getPeak(2).getCoord());
+  
         }
-
+     
         DataBank bankM = de.createBank("ECAL::moments", clusters.size());
-        for (int c = 0; c < clusters.size(); c++) {
+        for(int c = 0; c < clusters.size(); c++){
             bankM.setFloat("distU", c, (float) clusters.get(c).clusterPeaks.get(0).getDistanceEdge());
             bankM.setFloat("distV", c, (float) clusters.get(c).clusterPeaks.get(1).getDistanceEdge());
             bankM.setFloat("distW", c, (float) clusters.get(c).clusterPeaks.get(2).getDistanceEdge());
-            bankM.setFloat("m1u", c, (float) clusters.get(c).clusterPeaks.get(0).getMoment());
-            bankM.setFloat("m1v", c, (float) clusters.get(c).clusterPeaks.get(1).getMoment());
-            bankM.setFloat("m1w", c, (float) clusters.get(c).clusterPeaks.get(2).getMoment());
-            bankM.setFloat("m2u", c, (float) clusters.get(c).clusterPeaks.get(0).getMoment2());
-            bankM.setFloat("m2v", c, (float) clusters.get(c).clusterPeaks.get(1).getMoment2());
-            bankM.setFloat("m2w", c, (float) clusters.get(c).clusterPeaks.get(2).getMoment2());
-            bankM.setFloat("m3u", c, (float) clusters.get(c).clusterPeaks.get(0).getMoment3());
-            bankM.setFloat("m3v", c, (float) clusters.get(c).clusterPeaks.get(1).getMoment3());
-            bankM.setFloat("m3w", c, (float) clusters.get(c).clusterPeaks.get(2).getMoment3());
+            bankM.setFloat("m1u", c,   (float) clusters.get(c).clusterPeaks.get(0).getMoment());
+            bankM.setFloat("m1v", c,   (float) clusters.get(c).clusterPeaks.get(1).getMoment());
+            bankM.setFloat("m1w", c,   (float) clusters.get(c).clusterPeaks.get(2).getMoment());
+            bankM.setFloat("m2u", c,   (float) clusters.get(c).clusterPeaks.get(0).getMoment2());
+            bankM.setFloat("m2v", c,   (float) clusters.get(c).clusterPeaks.get(1).getMoment2());
+            bankM.setFloat("m2w", c,   (float) clusters.get(c).clusterPeaks.get(2).getMoment2());
+            bankM.setFloat("m3u", c,   (float) clusters.get(c).clusterPeaks.get(0).getMoment3());
+            bankM.setFloat("m3v", c,   (float) clusters.get(c).clusterPeaks.get(1).getMoment3());
+            bankM.setFloat("m3w", c,   (float) clusters.get(c).clusterPeaks.get(2).getMoment3());
         }
-
-        DataBank bankD = de.createBank("ECAL::calib", clusters.size());
-        for (int c = 0; c < clusters.size(); c++) {
-            bankD.setByte("sector", c, (byte) clusters.get(c).clusterPeaks.get(0).getDescriptor().getSector());
-            bankD.setByte("layer", c, (byte) clusters.get(c).clusterPeaks.get(0).getDescriptor().getLayer());
+                
+        DataBank  bankD =  de.createBank("ECAL::calib", clusters.size());
+         for(int c = 0; c < clusters.size(); c++){
+            bankD.setByte("sector",  c,  (byte) clusters.get(c).clusterPeaks.get(0).getDescriptor().getSector());
+            bankD.setByte("layer",   c,  (byte) clusters.get(c).clusterPeaks.get(0).getDescriptor().getLayer());
             bankD.setFloat("energy", c, (float) clusters.get(c).getEnergy());
-            bankD.setFloat("rawEU", c, (float) clusters.get(c).getRawEnergy(0));
-            bankD.setFloat("rawEV", c, (float) clusters.get(c).getRawEnergy(1));
-            bankD.setFloat("rawEW", c, (float) clusters.get(c).getRawEnergy(2));
-            bankD.setFloat("recEU", c, (float) clusters.get(c).getEnergy(0));
-            bankD.setFloat("recEV", c, (float) clusters.get(c).getEnergy(1));
-            bankD.setFloat("recEW", c, (float) clusters.get(c).getEnergy(2));
+            bankD.setFloat("rawEU",  c, (float) clusters.get(c).getRawEnergy(0));
+            bankD.setFloat("rawEV",  c, (float) clusters.get(c).getRawEnergy(1));
+            bankD.setFloat("rawEW",  c, (float) clusters.get(c).getRawEnergy(2));
+            bankD.setFloat("recEU",  c, (float) clusters.get(c).getEnergy(0));
+            bankD.setFloat("recEV",  c, (float) clusters.get(c).getEnergy(1));
+            bankD.setFloat("recEW",  c, (float) clusters.get(c).getEnergy(2));            
         }
-
-        de.appendBanks(bankS, bankP, bankC, bankD, bankM);
+         
+         de.appendBanks(bankS,bankP,bankC,bankD,bankM);
 //         de.appendBanks(bankS,bankP,bankC,bankD);
 
     }
-
+   
     public void setCalRun(int runno) {
-        System.out.println("ECEngine: Calibration Run Number = " + runno);
+        System.out.println("ECEngine: Calibration Run Number = "+runno);
         this.calrun = runno;
     }
-
+    
     public void setVariation(String variation) {
-        System.out.println("ECEngine: Variation = " + variation);
+        System.out.println("ECEngine: Variation = "+variation);
         ECCommon.variation = variation;
-    }
-
+    } 
+    
     public void setVeff(float veff) {
-        System.out.println("ECEngine: Veff = " + veff);
-        ECCommon.veff = veff;
+        System.out.println("ECEngine: Veff = "+veff);
+    	    ECCommon.veff = veff;
     }
-
+    
     public void setNewTimeCal(boolean val) {
-        System.out.println("ECEngine: useNewTimeCal = " + val);
-        ECCommon.useNewTimeCal = val;
+        System.out.println("ECEngine: useNewTimeCal = "+val);
+    	ECCommon.useNewTimeCal = val;
     }
-
+    
     public void setStripThresholds(int thr0, int thr1, int thr2) {
-        System.out.println("ECEngine: Strip ADC thresholds = " + thr0 + " " + thr1 + " " + thr2);
+        System.out.println("ECEngine: Strip ADC thresholds = "+thr0+" "+thr1+" "+thr2);
         ECCommon.stripThreshold[0] = thr0;
         ECCommon.stripThreshold[1] = thr1;
         ECCommon.stripThreshold[2] = thr2;
     }
-
+    
     public void setPeakThresholds(int thr0, int thr1, int thr2) {
-        System.out.println("ECEngine: Peak ADC thresholds = " + thr0 + " " + thr1 + " " + thr2);
+        System.out.println("ECEngine: Peak ADC thresholds = "+thr0+" "+thr1+" "+thr2);
         ECCommon.peakThreshold[0] = thr0;
         ECCommon.peakThreshold[1] = thr1;
         ECCommon.peakThreshold[2] = thr2;
-    }
-
+    }   
+    
     public void setClusterCuts(float err0, float err1, float err2) {
-        System.out.println("ECEngine: Cluster Dalitz Cuts = " + err0 + " " + err1 + " " + err2);
+        System.out.println("ECEngine: Cluster Dalitz Cuts = "+err0+" "+err1+" "+err2);
         ECCommon.clusterError[0] = err0;
         ECCommon.clusterError[1] = err1;
         ECCommon.clusterError[2] = err2;
     }
-
-    public DetectorCollection<H1F> getHist() {
+    
+    public DetectorCollection<H1F>  getHist() {
         return ECCommon.H1_ecEng;
     }
-
+    
     @Override
     public boolean init() {
-
-        String[] ecTables = new String[]{
-            "/calibration/ec/attenuation",
-            "/calibration/ec/gain",
+    	
+        String[]  ecTables = new String[]{
+            "/calibration/ec/attenuation", 
+            "/calibration/ec/gain", 
             "/calibration/ec/timing",
             "/calibration/ec/time_jitter",
             "/calibration/ec/fadc_offset",
@@ -269,21 +256,20 @@ public class ECEngine extends ReconstructionEngine {
             "/calibration/ec/tmf_offset",
             "/calibration/ec/tmf_window"
         };
-
+        
+        
         requireConstants(Arrays.asList(ecTables));
         getConstantsManager().setVariation(ECCommon.variation);
         String variationName = Optional.ofNullable(this.getEngineConfigString("variation")).orElse("default");
-        ecDetector = GeometryFactory.getDetector(DetectorType.ECAL, 11, variationName);
+        ecDetector =  GeometryFactory.getDetector(DetectorType.ECAL,11,variationName);
 
         setCalRun(2);
-        setStripThresholds(10, 9, 8);
-        setPeakThresholds(18, 20, 15);
-        setClusterCuts(7, 15, 20);
-
-        if (isSingleThreaded) {
-            ECCommon.initHistos();
-        }
+        setStripThresholds(10,9,8);
+        setPeakThresholds(18,20,15);
+        setClusterCuts(7,15,20);
+        
+        if (isSingleThreaded) ECCommon.initHistos();
         return true;
     }
-
+    
 }

--- a/reconstruction/ec/src/main/java/org/jlab/service/ec/ECEngine.java
+++ b/reconstruction/ec/src/main/java/org/jlab/service/ec/ECEngine.java
@@ -102,8 +102,9 @@ public class ECEngine extends ReconstructionEngine {
             bankS.setByte("layer",   h,  (byte) strips.get(h).getDescriptor().getLayer());
             bankS.setByte("strip",   h,  (byte) strips.get(h).getDescriptor().getComponent());
             bankS.setByte("peakid",  h,  (byte) strips.get(h).getPeakId());
+            bankS.setShort("id",     h, (short) strips.get(h).getID());
             bankS.setFloat("energy", h, (float) strips.get(h).getEnergy());
-            bankS.setFloat("time",   h, (float) strips.get(h).getTime());                
+            bankS.setFloat("time",   h, (float) strips.get(h).getTime());
         }
        
         DataBank  bankP =  de.createBank("ECAL::peaks", peaks.size());

--- a/reconstruction/ec/src/main/java/org/jlab/service/ec/ECPeak.java
+++ b/reconstruction/ec/src/main/java/org/jlab/service/ec/ECPeak.java
@@ -102,6 +102,10 @@ public class ECPeak {
         return false;
     }
     
+    public List<ECStrip> getStrips(){
+        return this.peakStrips;
+    }
+    
     public int getADC(){
         int adc = 0;
         for(ECStrip s : this.peakStrips){

--- a/reconstruction/ec/src/main/java/org/jlab/service/ec/ECStrip.java
+++ b/reconstruction/ec/src/main/java/org/jlab/service/ec/ECStrip.java
@@ -36,6 +36,7 @@ public class ECStrip implements Comparable {
 	private int        triggerPhase = 0;
 	private double             veff = 18.1; // Effective velocity of scintillator light (cm/ns)
 	private int              peakID = -1;
+        private int              id = -1;       // ID of the hit. this shows the row number of the corresponding hit in the ADC bank
 	
 	private double              tdist=0;
 	private double              edist=0;
@@ -166,6 +167,15 @@ public class ECStrip implements Comparable {
     public int getPeakId(){
       	return this.peakID;
     	}
+    
+    public void setID(int id){
+            this.id = id;
+    }
+    
+    public int getID(){
+            return this.id;
+    }
+    
     
     public void setAttenuation(double a, double b, double c){
         this.iAttenLengthA = a;

--- a/reconstruction/ec/src/main/java/org/jlab/service/ec/ECStrip.java
+++ b/reconstruction/ec/src/main/java/org/jlab/service/ec/ECStrip.java
@@ -36,7 +36,8 @@ public class ECStrip implements Comparable {
 	private int        triggerPhase = 0;
 	private double             veff = 18.1; // Effective velocity of scintillator light (cm/ns)
 	private int              peakID = -1;
-        private int              id = -1;       // ID of the hit. this shows the row number of the corresponding hit in the ADC bank
+        private int                  id = -1;       // ID of the hit. this shows the row number of the corresponding hit in the ADC bank
+        private int           clusterId = -1;       // Id (row number) of the cluster that this hit belongs to
 	
 	private double              tdist=0;
 	private double              edist=0;
@@ -176,6 +177,14 @@ public class ECStrip implements Comparable {
             return this.id;
     }
     
+    public void setClusterId(int id){
+            this.clusterId = id;
+    }
+    
+    public int getClusterId(){
+            return this.clusterId;
+    }
+        
     
     public void setAttenuation(double a, double b, double c){
         this.iAttenLengthA = a;

--- a/reconstruction/mc/pom.xml
+++ b/reconstruction/mc/pom.xml
@@ -9,6 +9,19 @@
   <version>1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
+  <build>
+      <plugins>
+          <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-compiler-plugin</artifactId>
+              <configuration>
+                  <source>1.8</source>
+                  <target>1.8</target>
+              </configuration>
+          </plugin>
+      </plugins>
+  </build>
+
   <parent>
     <groupId>org.jlab.clas</groupId>
     <artifactId>clas12rec</artifactId>


### PR DESCRIPTION
* variable "id" in the ECAL::hits bank is filled to represent the ADC row number of corresponding hit in ADC bank,
* the variable "clusterId" is added in the ECAL::hits bank, it points to the cluster row number of the cluster (to which the hit belongs to) in the ECAL::clusters bank.

Sorry the netbeans automatically formatted the  ECEngine file,
if this is an issue, I can check it out again, and add my modification.