### PR TITLE
mvn clean coat-lib in build script

### DIFF
--- a/build-coatjava.sh
+++ b/build-coatjava.sh
@@ -73,6 +73,7 @@ mkdir -p coatjava/lib/services
 ### clean up any cache copies ###
 rm -rf ~/.m2/repository/org/hep/hipo
 rm -rf ~/.m2/repository/org/jlab
+cd common-tools/coat-lib; $mvn clean; cd -
 
 unset CLAS12DIR
 if [ $runUnitTests == "yes" ]; then


### PR DESCRIPTION
to avoid confusion with multiple simultaneous versions