### PR TITLE
Return for tracks not swimmable to HTCC sphere.

### DIFF
--- a/reconstruction/dc/src/main/java/org/jlab/rec/dc/track/TrackCandListFinder.java
+++ b/reconstruction/dc/src/main/java/org/jlab/rec/dc/track/TrackCandListFinder.java
@@ -462,9 +462,10 @@ public class TrackCandListFinder {
 
         // swimming to a ref points outside of the last DC region
         double[] VecAtTarOut = dcSwim.SwimToPlaneTiltSecSys(cand.get(0).get_Sector(), 592);
-        if(VecAtTarOut==null)
+        if(VecAtTarOut==null) {
+            cand.fit_Successful = false;
             return;
-        
+        }
         double xOuter = VecAtTarOut[0];
         double yOuter = VecAtTarOut[1];
         double zOuter = VecAtTarOut[2];
@@ -523,8 +524,10 @@ public class TrackCandListFinder {
         
         
         double[] Vt = dcSwim.SwimToBeamLine(xB, yB);
-        if(Vt==null)
+        if(Vt==null) {
+            cand.fit_Successful = false;
             return;
+        }
         
        // recalc new vertex using plane stopper
         //int sector = cand.get(2).get_Sector();
@@ -560,6 +563,10 @@ public class TrackCandListFinder {
                 pxOrFix, pyOrFix, pzOrFix,
                 cand.get_Q());
         double[] VecAtHtccSurf = dcSwim.SwimToSphere(175);
+        if(VecAtHtccSurf==null) {
+            cand.fit_Successful = false;
+            return;
+        }
         double xInner = VecAtHtccSurf[0];
         double yInner = VecAtHtccSurf[1];
         double zInner = VecAtHtccSurf[2];
@@ -844,15 +851,17 @@ public class TrackCandListFinder {
                         cand.set_P(1. / Math.abs(kFit.finalStateVec.Q));
                         cand.set_Q((int) Math.signum(kFit.finalStateVec.Q));
                         this.setTrackPars(cand, traj, trjFind, fn, kFit.finalStateVec.z, DcDetector, dcSwim);
-                        // candidate parameters are set from the state vector
-                        cand.set_FitChi2(kFit.chi2);
-                        cand.set_FitNDF(kFit.NDF);
-                        cand.set_FitConvergenceStatus(kFit.ConvStatus);
-                        cand.set_Id(cands.size() + 1);
-                        cand.set_CovMat(kFit.finalCovMat.covMat);
-                        cand.set_Trajectory(kFit.kfStateVecsAlongTrajectory);
-                        // add candidate to list of tracks
-                        cands.add(cand);
+                        if(cand.fit_Successful==true) {
+                            // candidate parameters are set from the state vector
+                            cand.set_FitChi2(kFit.chi2);
+                            cand.set_FitNDF(kFit.NDF);
+                            cand.set_FitConvergenceStatus(kFit.ConvStatus);
+                            cand.set_Id(cands.size() + 1);
+                            cand.set_CovMat(kFit.finalCovMat.covMat);
+                            cand.set_Trajectory(kFit.kfStateVecsAlongTrajectory);
+                            // add candidate to list of tracks
+                            cands.add(cand);
+                        }
                     }
                     //this.matchHits(traj.get_Trajectory(), cand, DcDetector);
                     cands.add(cand);

--- a/reconstruction/dc/src/main/java/org/jlab/service/dc/DCTBEngine.java
+++ b/reconstruction/dc/src/main/java/org/jlab/service/dc/DCTBEngine.java
@@ -235,6 +235,8 @@ public class DCTBEngine extends DCEngine {
                 trkcandFinder.setTrackPars(TrackArray[i], new Trajectory(), trjFind, fn, 
                         kFit.finalStateVec.z, dcDetector, dcSwim, beamXoffset, beamYoffset);
                 // candidate parameters are set from the state vector
+                if(TrackArray[i].fit_Successful==false)
+                    continue;
                 TrackArray[i].set_FitChi2(kFit.chi2); 
                 TrackArray[i].set_FitNDF(kFit.NDF);
                 TrackArray[i].set_Trajectory(kFit.kfStateVecsAlongTrajectory);


### PR DESCRIPTION
Set fail flag for track not swimmable to reference surfaces used for EB matching to detectors.
Pass only tracks with on-fail flag.