### PR TITLE
Iss582 helflip

### DIFF
--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/DaqScalersSequence.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/DaqScalersSequence.java
@@ -24,6 +24,8 @@ public class DaqScalersSequence implements Comparator<DaqScalers> {
     public static final double TI_CLOCK_FREQ = 250e6; // Hz
     
     protected final List<DaqScalers> scalers=new ArrayList<>();
+    
+    private Bank rcfgBank=null;
   
     public class Interval {
         private DaqScalers previous = null;
@@ -116,19 +118,51 @@ public class DaqScalersSequence implements Comparator<DaqScalers> {
     }
 
     /**
+     * @param event 
+     * @return the most recent DaqScalers for the given event
+     */
+    public DaqScalers get(Event event) {
+        event.read(this.rcfgBank);
+        return this.get(this.rcfgBank.getLong("timestamp", 0));
+    }
+
+    /**
      * @param timestamp TI timestamp (i.e. RUN::config.timestamp)
      * @return smallest interval of scaler readings around that timestamp
      */
     public Interval getInterval(long timestamp) {
         return this.getInterval(timestamp,timestamp);
     }
+    
+    /**
+     * @param event
+     * @return smallest interval of scaler readings around that event
+     */
+    public Interval getInterval(Event event) {
+        event.read(this.rcfgBank);
+        return this.getInterval(this.rcfgBank.getLong("timestamp", 0));
+    }
+
     /**
      * @param t1 first TI timestamp (i.e. RUN::config.timestamp)
      * @param t2 second TI timestamp
-     * @return an interval of scaler readings around those timestamps
+     * @return smallest interval of scaler readings around those timestamps
      */
     public Interval getInterval(long t1,long t2) {
         return new Interval(this,t1,t2);
+    }
+    
+    /**
+     * @param event1 first event
+     * @param event2 second event
+     * @return smallest interval of scaler readings around those events
+     */
+    public Interval getInterval(Event event1, Event event2) {
+        event1.read(this.rcfgBank);
+        final long t1 = this.rcfgBank.getLong("timestamp",0);
+        event2.read(this.rcfgBank);
+        final long t2 = this.rcfgBank.getLong("timestamp",0);
+        return this.getInterval(t1,t2);
     }
 
     /**
@@ -148,6 +182,10 @@ public class DaqScalersSequence implements Comparator<DaqScalers> {
             HipoReader reader = new HipoReader();
             reader.setTags(1);
             reader.open(filename);
+
+            if (seq.rcfgBank==null) {
+                seq.rcfgBank = new Bank(reader.getSchemaFactory().getSchema("RUN::config"));
+            }
         
             SchemaFactory schema = reader.getSchemaFactory();
         

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/HelicitySequenceManager.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/HelicitySequenceManager.java
@@ -21,15 +21,28 @@ public final class HelicitySequenceManager {
     SchemaFactory schema=null;
     private final int delay;
     private int verbosity=1;
+    private boolean flip=false;
     private volatile Map<Integer,HelicitySequenceDelayed> seqMap=new HashMap<>();
     Bank rcfgBank=null;
     
+    public HelicitySequenceManager(int delay,List<String> filenames,boolean flip) {
+        this.flip=flip;
+        this.delay=delay;
+        initialize(filenames);
+    }
+
     public HelicitySequenceManager(int delay,List<String> filenames) {
         this.delay=delay;
         initialize(filenames);
     }
     
     private HelicitySequenceManager(int delay,HipoReader reader) {
+        this.delay=delay;
+        initialize(reader);
+    }
+    
+    private HelicitySequenceManager(int delay,HipoReader reader,boolean flip) {
+        this.flip=flip;
         this.delay=delay;
         initialize(reader);
     }
@@ -51,7 +64,7 @@ public final class HelicitySequenceManager {
               System.exit(1);
             }
         }
-        return seqMap.get(runno).addState(state);
+        return seqMap.get(runno).addState(this.flip?state.invert():state);
     }
 
     public HelicitySequence getSequence(int runno) {

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/HelicityState.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/HelicityState.java
@@ -114,6 +114,10 @@ public class HelicityState implements Comparable<HelicityState>, Comparator<Heli
         if (state.helicityRaw==HelicityBit.UDF) state.hwStatus |= Mask.HELICITY;
         if (state.pairSync==HelicityBit.UDF)    state.hwStatus |= Mask.SYNC;
         if (state.patternSync==HelicityBit.UDF) state.hwStatus |= Mask.PATTERN;
+
+        // Fix the overall sign-convention error in the offline helicity:
+        state.invert();
+        
         state.fixMissingReadouts();
         return state;
     }
@@ -251,5 +255,15 @@ public class HelicityState implements Comparable<HelicityState>, Comparator<Heli
     public HelicityBit getHelicity() { return this.helicity; }
     public HelicityBit getPairSync() { return this.pairSync; }
     public HelicityBit getPatternSync() { return this.patternSync; }
+
+    /**
+     * Inverts the helicity/helicityRaw components of this state
+     * @return this state after inversion
+     */
+    public HelicityState invert() {
+       this.helicity = HelicityBit.getFlipped(this.helicity);
+       this.helicityRaw = HelicityBit.getFlipped(this.helicityRaw);
+       return this;
+    }
 
 }


### PR DESCRIPTION
* flip offline helicity at transition from `HEL::adc` to `HEL:flip` during decoding
  * based on well-known physics reactions measured by CLAS12
  * still unknown where the sign convention is broken, online or offline
  * note that `HEL:adc` is left with the old convention, as it's a raw FADC voltage value
* provides post-processing methods to preform the flip in previously decoded data
  * both `HEL::flip` and `REC::Event  `