### PR TITLE
Make CI logs less noisy

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         java-version: 11
     - name: build
-      run: ./build-coatjava.sh --spotbugs --unittests
+      run: ./build-coatjava.sh --spotbugs --unittests --quiet
     - name: kpp-test
       run: cd validation/advanced-tests && ./run-advanced-tests.sh
     - name: eb-ep-test


### PR DESCRIPTION
The --quiet got dropped when moving from Travis to Github Actions