### PR TITLE
accommodate no helicity states found

### DIFF
--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/HelicitySequence.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/HelicitySequence.java
@@ -148,6 +148,7 @@ class HelicitySequence {
      */
     protected final int searchIndex(long timestamp) {
         if (!this.analyzed) this.analyze();
+        if (this.size() == 0) return -1;
         if (timestamp < this.getTimestamp(0)) return -1;
         if (timestamp > this.getTimestamp(this.size()-1)) return -1;
         // make a fake state for timestamp search:


### PR DESCRIPTION
This happened in BONuS, when the DAQ wrote a few events with the wrong run number, e.g. run 12069 somewhere in files 00005-00009.