### PR TITLE
update freehep maven urls

### DIFF
--- a/common-tools/coat-lib/pom.xml
+++ b/common-tools/coat-lib/pom.xml
@@ -24,6 +24,10 @@
       <id>jnp-build</id>
       <url>https://clasweb.jlab.org/jhep/maven</url>
     </repository>
+    <repository>
+     <id>freehep-repo-public</id>
+     <url>https://srs.slac.stanford.edu/nexus/content/groups/freehep-maven2-public/</url>
+    </repository>
   </repositories>
 
   <!-- project Dependencies -->

--- a/maven-settings.xml
+++ b/maven-settings.xml
@@ -11,7 +11,8 @@ that is pulling it in.
             <id>new-freehep</id>
             <mirrorOf>freehep</mirrorOf>
             <name>freehep</name>
-            <url>https://java.freehep.org/maven2</url>
+            <!--<url>https://java.freehep.org/maven2</url>-->
+            <url>https://srs.slac.stanford.edu/nexus/content/groups/freehep-maven2-public/</url>
         </mirror>
     </mirrors>
 </settings>


### PR DESCRIPTION
to what HPS uses, and java.freehep.org is down and a recurring problem, address #738 