### PR TITLE
Iss818 cvt seed beam spot

### DIFF
--- a/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/fit/CircleFitPars.java
+++ b/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/fit/CircleFitPars.java
@@ -88,4 +88,45 @@ public class CircleFitPars {
         return tmpmat;
     }
 
+    /**
+     * Returns the circle radius
+     * @return 
+     */
+    public double radius() {
+        return 1. / _rho;
+    }
+
+    /**
+     * Returns the circle center x coordinate
+     * @return 
+     */
+    public double xc() {
+        return (radius() - _dca) * Math.sin(_phi) + _xref;
+    }
+
+    /**
+     * Returns the circle center y coordinate
+     * @return 
+     */
+    public double yc() {
+        return (-radius() + _dca) * Math.cos(_phi) + _yref;
+    }
+
+    /**
+     * Returns the circle arc length between two points
+     * @param x1
+     * @param y1
+     * @param x2
+     * @param y2
+     * @return 
+     */
+    public double arcLength(double x1, double y1, double x2, double y2) {
+        double phi1  = Math.atan2(y1-yc(), x1-xc());
+        double phi2  = Math.atan2(y2-yc(), x2-xc());
+        double dphi = phi2 - phi1;
+        if(Math.abs(dphi)>Math.PI) dphi -= Math.signum(dphi)*2*Math.PI;
+        return -radius()*dphi;
+    }
+
+
 }

--- a/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/fit/HelicalTrackFitter.java
+++ b/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/fit/HelicalTrackFitter.java
@@ -156,9 +156,8 @@ public class HelicalTrackFitter {
         double fit_phi_at_dca = _circlefitpars.phi();
         double fit_curvature = _circlefitpars.rho();
         double fit_tandip = _linefitpars.slope();
-        double fit_Z0 = _linefitpars.intercept();
-        //fit_Z0 = (Math.abs(fit_dca)-_linefitpars.intercept())/ _linefitpars.slope() ; //reset for displaced vertex
-        //System.out.println("fit z0 "+_linefitpars.intercept());
+        double fit_Z0 = _linefitpars.intercept() - _circlefitpars.arcLength(xb, yb, 0, 0)*fit_tandip;
+
         //require vertex position inside of the inner barrel
         if (Math.abs(fit_dca) > SVTGeometry.getLayerRadius(1)) {
 //            if (Math.abs(fit_dca) > Constants.MODULERADIUS[0][0] || Math.abs(fit_Z0) > 100) {

--- a/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/fit/LineFitPars.java
+++ b/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/fit/LineFitPars.java
@@ -69,6 +69,10 @@ public class LineFitPars {
         return ProbChi2perNDF.prob(chi2, ndf);
     }
     
+    public double getValue(double x) {
+        return x * _slope + _interc;
+    }
+    
     public Ray getYXRay() {
         return new Ray(this._slope, this._slopeErr, this._interc, this._intercErr, 0, 0, 0, 0);
     }

--- a/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/fit/StraightTrackFitter.java
+++ b/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/fit/StraightTrackFitter.java
@@ -144,7 +144,7 @@ public class StraightTrackFitter {
         Helix helixresult = new Helix(fit_dca, fit_phi_at_dca, fit_curvature, fit_Z0, fit_tandip, this.getXb(), this.getYb(), fit_covmatrix);
 
         setHelix(helixresult);
-        _chisq[0] = _xyfitpars.chisq();
+        _chisq[0] = _linefitpars.chisq();
         _chisq[1] = _linefitpars.chisq();
 
         //System.out.println("chi2 "+_chisq[0]+" " + _chisq[1]);

--- a/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/fit/StraightTrackFitter.java
+++ b/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/fit/StraightTrackFitter.java
@@ -7,6 +7,7 @@ import org.jlab.rec.cvt.trajectory.Helix;
 
 import org.jlab.geom.prim.Line3D;
 import org.jlab.geom.prim.Point3D;
+import org.jlab.geom.prim.Vector3D;
 import org.jlab.rec.cvt.svt.SVTGeometry;
 
 
@@ -21,8 +22,9 @@ public class StraightTrackFitter {
     private Helix _helix;  // fit helix
     private double[] _chisq = new double[2];  // fit chi-squared [0]: circle [1] line
 
-    private LineFitter _xyfit = new LineFitter();
+    private LineFitter _xyfit   = new LineFitter();
     private LineFitter _linefit = new LineFitter();
+    private LineFitPars _xyfitpars;
     private LineFitPars _linefitpars;
     private HelicalTrackFitPars _helicalfitoutput;
     private double Xb;
@@ -57,11 +59,12 @@ public class StraightTrackFitter {
 
     private final List<Double> W = new ArrayList<>();
 
-    public FitStatus fit(List<Double> X, List<Double> Y, List<Double> Z, List<Double> Rho, List<Double> errRt, List<Double> errRho, List<Double> ErrZ) {
+    public FitStatus fit(List<Double> X, List<Double> Y, List<Double> Z, List<Double> Rho, 
+                         List<Double> errRt, List<Double> errRho, List<Double> ErrZ,
+                         double xb, double yb) {
         //  Initialize the various fitter outputs
-        
-        _linefitpars = null;
-        _helicalfitoutput = null;
+        Xb = xb;
+        Yb = yb;
         _chisq[0] = 0;
         _chisq[1] = 0;
         W.clear();
@@ -76,44 +79,38 @@ public class StraightTrackFitter {
         // check the status
         _xyfit = new LineFitter();
         boolean xyfitstatusOK = _xyfit.fitStatus(X, Y, W, new ArrayList<>(X.size()), X.size());
-        double slope = _xyfit.getFit().slope();
-        double intercept = _xyfit.getFit().intercept();
-        Line3D line = new Line3D(new Point3D(X.get(0),slope*X.get(0)+intercept,0), new Point3D(X.get(1),slope*X.get(1)+intercept,0));
-        double fit_dca = 0;
-        Point3D xydoca = line.distance(new Point3D(this.getXb(), this.getYb(),0)).origin();
-        
-        double fit_phi_at_dca = line.direction().phi();
-        
-        if(Math.abs(Math.atan2(Y.get(0),X.get(0))-fit_phi_at_dca)>Math.PI/2) {
-            fit_phi_at_dca+=Math.PI;
-        }
-        double x = xydoca.x();
-        double y = xydoca.y();
-        fit_dca = Math.atan2(-x,y);
-        if(Math.cos(fit_phi_at_dca)>0.1) {
-            fit_dca = y/Math.cos(fit_phi_at_dca);
-        } else {
-            fit_dca = -x/Math.sin(fit_phi_at_dca);
-        }
+        if (!xyfitstatusOK) {
+            return FitStatus.LineFitFailed; 
+        }        
+        _xyfitpars = _xyfit.getFit();
         
         //Line fit
         _linefit = new LineFitter();
-
         boolean linefitstatusOK = _linefit.fitStatus(Rho, Z, errRho, ErrZ, Z.size());
-
         if (!linefitstatusOK) {
             return FitStatus.LineFitFailed; 
         }
-        //  Get the results of the fits
         _linefitpars = _linefit.getFit();
-
-        // get the parameters of the helix representation of the track
-        double fit_curvature = 1.e-12;
+        
+        Line3D  line = new Line3D(this.getPoint(X.get(0)), this.getPoint(X.get(1)));
+        Line3D  beam = new Line3D(new Point3D(this.getXb(), this.getYb(),0), new Vector3D(0,0,1));
+        Point3D doca = line.distance(beam).origin();
+        
+        double fit_phi_at_dca = line.direction().phi();
+        if(Math.abs(Math.atan2(Y.get(0),X.get(0))-fit_phi_at_dca)>Math.PI/2) {
+            fit_phi_at_dca+=Math.PI;
+        }
+        double fit_dca = 0;
+        if(Math.cos(fit_phi_at_dca)>0.1) {
+            fit_dca = (doca.y()-getYb())/Math.cos(fit_phi_at_dca);
+        } else {
+            fit_dca = -(doca.x()-getXb())/Math.sin(fit_phi_at_dca);
+        }
         double fit_tandip = _linefitpars.slope();
+        double fit_Z0 = doca.z();
+        double fit_curvature = 1.e-12;
+        
 
-        //double fit_Z0 = _linefitpars.intercept();
-        double fit_Z0 = _linefitpars.intercept();
-        //fit_Z0 = (Math.abs(fit_dca)-_linefitpars.intercept())/ _linefitpars.slope() ; //reset for displaced vertex
         //require vertex position inside of the inner barrel
             if (Math.abs(fit_dca) > SVTGeometry.getLayerRadius(1) || Math.abs(fit_Z0) > 100) {
             return null;
@@ -138,16 +135,16 @@ public class StraightTrackFitter {
         //covr[4] =  delta_phi.delta_dca;
         //covr[5] =  delta_dca.delta_dca;
         
-        fit_covmatrix[0][0] = _xyfit.getFit().interceptErr() * _xyfit.getFit().interceptErr();
-        fit_covmatrix[1][1] = _xyfit.getFit().slopeErr() * _xyfit.getFit().slopeErr();
+        fit_covmatrix[0][0] = _xyfitpars.interceptErr() * _xyfitpars.interceptErr();
+        fit_covmatrix[1][1] = _xyfitpars.slopeErr() * _xyfitpars.slopeErr();
         fit_covmatrix[2][2] = 1.e-08;
         fit_covmatrix[3][3] = _linefitpars.interceptErr() * _linefitpars.interceptErr();
         fit_covmatrix[4][4] = _linefitpars.slopeErr() * _linefitpars.slopeErr();
 
-        Helix helixresult = new Helix(fit_dca, fit_phi_at_dca, fit_curvature, fit_Z0, fit_tandip, 0, 0, fit_covmatrix);
+        Helix helixresult = new Helix(fit_dca, fit_phi_at_dca, fit_curvature, fit_Z0, fit_tandip, this.getXb(), this.getYb(), fit_covmatrix);
 
         setHelix(helixresult);
-        _chisq[0] = _linefitpars.chisq();
+        _chisq[0] = _xyfitpars.chisq();
         _chisq[1] = _linefitpars.chisq();
 
         //System.out.println("chi2 "+_chisq[0]+" " + _chisq[1]);
@@ -226,4 +223,13 @@ public class StraightTrackFitter {
         this.Yb = Yb;
     }
 
+    public Point3D getPoint(double x) {
+        if(_xyfitpars==null || _linefitpars==null) 
+            return null;
+        
+        double y = _xyfitpars.getValue(x);
+        double z = _linefitpars.getValue(Math.sqrt(x*x+y*y));
+        return new Point3D(x, y, z);
+    }
+    
 }

--- a/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/track/StraightTrackSeeder.java
+++ b/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/track/StraightTrackSeeder.java
@@ -460,7 +460,7 @@ public class StraightTrackSeeder {
             //Y.add((double) Constants.getYb());
             //ErrRt.add((double) 0.1);
             
-            fitTrk.fit(X, Y, Z, Rho, ErrRt, ErrRho, ErrZ);
+            fitTrk.fit(X, Y, Z, Rho, ErrRt, ErrRho, ErrZ, xbeam, ybeam);
             
             if (fitTrk.getHelix() == null) { 
                 return null;


### PR DESCRIPTION
Use the beam spot coordinates in calculating the helix parameters from the seed fit. 
For straight tracks from target, this fixes the values of d0, phi0 and z0, removing a bias in the seed helix that was not being recovered by the KF if the beam spot offset from (0,0) was large, i.e. of the order of 1 mm.
For curved tracks, this fix affects only z0 and has marginal effect because the KF was recovering any way.

This addresses issue #818 