### PR TITLE
recon utils to update dictionary

### DIFF
--- a/common-tools/clas-io/src/main/java/org/jlab/io/hipo/HipoDataSync.java
+++ b/common-tools/clas-io/src/main/java/org/jlab/io/hipo/HipoDataSync.java
@@ -74,7 +74,8 @@ public class HipoDataSync implements DataSync {
             this.writer.addEvent(hipoEvent.getHipoEvent(),hipoEvent.getHipoEvent().getEventTag());
         }
     }
-
+    public HipoWriterSorted getWriter(){ return writer;}
+    
     public void close() {
         this.writer.close();
     }


### PR DESCRIPTION
engine processor has been modified to update the dictionary of old files when cooking. A new flag is introduced to turn this feature off if necessary (it's on by default). This mode will also work on files that were stripped off reconstruction schemas, leaving only ADC and TDC banks (plus some run info banks).