### PR TITLE
fixed the EvioSource code to read all the events in the file (without…

### DIFF
--- a/common-tools/clas-io/src/main/java/org/jlab/io/evio/EvioSource.java
+++ b/common-tools/clas-io/src/main/java/org/jlab/io/evio/EvioSource.java
@@ -219,7 +219,7 @@ public class EvioSource implements DataSource {
 	 */
 
 	public boolean hasEvent() {
-		if (currentEvent >= currentFileEntries)
+		if (currentEvent > currentFileEntries)
 			return false;
 		return true;
 	}


### PR DESCRIPTION
… skipping the last one)
The bug in hasEvent() method of EvioSource was fixed. Now EvioSource reads all events in the file.
It was tested on clas_016214.evio.00000 RG-C file.

Here is the info printout before the fix:
$PROJECT/jaw-2.3/bin/hipoutils.sh -info ~/Work/DataSpace/hipo/clas_016214.evio.00000.h5

****>>>> index tag :        0, count =       173, entries =     57310, data length = 553404608
****>>>> index tag :        1, count =         1, entries =      1565, data length =     81408

Here is after the fix:
[~issSomething/clas12-offline-software~]>$PROJECT/jaw-2.3/bin/hipoutils.sh -info ~/Work/DataSpace/hipo/clas_016214.evio.00000.iss918.h5 
****>>>> index tag :        0, count =       173, entries =     57311, data length = 553414128
****>>>> index tag :        1, count =         1, entries =      1565, data length =     81408

After the fix has one more event, and it has different event# in RUN::Config
