### PR TITLE
Address scaler readout issues

### DIFF
--- a/common-tools/clas-analysis/src/main/java/org/jlab/analysis/postprocess/RebuildScalers.java
+++ b/common-tools/clas-analysis/src/main/java/org/jlab/analysis/postprocess/RebuildScalers.java
@@ -26,6 +26,7 @@ public class RebuildScalers {
 
     static final String CCDB_FCUP_TABLE="/runcontrol/fcup";
     static final String CCDB_SLM_TABLE="/runcontrol/slm";
+    static final String CCDB_HEL_TABLE="/runcontrol/slm";
     
     public static void main(String[] args) {
 
@@ -55,7 +56,7 @@ public class RebuildScalers {
         Bank runConfigBank = new Bank(writer.getSchemaFactory().getSchema("RUN::config"));
             
         ConstantsManager conman = new ConstantsManager();
-        conman.init(Arrays.asList(new String[]{CCDB_FCUP_TABLE,CCDB_SLM_TABLE}));
+        conman.init(Arrays.asList(new String[]{CCDB_FCUP_TABLE,CCDB_SLM_TABLE,CCDB_HEL_TABLE}));
         
         for (String filename : inputList) {
 
@@ -65,6 +66,7 @@ public class RebuildScalers {
             RCDBConstants rcdb = null;
             IndexedTable ccdb_fcup = null;
             IndexedTable ccdb_slm = null;
+            IndexedTable ccdb_hel = null;
 
             while (reader.hasNext()) {
 
@@ -83,6 +85,7 @@ public class RebuildScalers {
                 if (runConfigBank.getInt("run",0) >= 100) {
                     ccdb_fcup = conman.getConstants(runConfigBank.getInt("run",0),CCDB_FCUP_TABLE);
                     ccdb_slm = conman.getConstants(runConfigBank.getInt("run",0),CCDB_SLM_TABLE);
+                    ccdb_hel = conman.getConstants(runConfigBank.getInt("run",0),CCDB_HEL_TABLE);
                     rcdb = conman.getRcdbConstants(runConfigBank.getInt("run",0));
                 }
 
@@ -94,7 +97,7 @@ public class RebuildScalers {
                     Time rst = rcdb.getTime("run_start_time");
                     Date uet = new Date(runConfigBank.getInt("unixtime",0)*1000L);
        
-                    DaqScalers ds = DaqScalers.create(rawScalerBank, ccdb_fcup, ccdb_slm, rst, uet);
+                    DaqScalers ds = DaqScalers.create(rawScalerBank, ccdb_fcup, ccdb_slm, ccdb_hel, rst, uet);
                     runScalerBank = ds.createRunBank(writer.getSchemaFactory());
                     helScalerBank = ds.createHelicityBank(writer.getSchemaFactory());
                     

--- a/common-tools/clas-analysis/src/main/java/org/jlab/analysis/postprocess/RebuildScalers.java
+++ b/common-tools/clas-analysis/src/main/java/org/jlab/analysis/postprocess/RebuildScalers.java
@@ -26,7 +26,7 @@ public class RebuildScalers {
 
     static final String CCDB_FCUP_TABLE="/runcontrol/fcup";
     static final String CCDB_SLM_TABLE="/runcontrol/slm";
-    static final String CCDB_HEL_TABLE="/runcontrol/slm";
+    static final String CCDB_HEL_TABLE="/runcontrol/helicity";
     
     public static void main(String[] args) {
 

--- a/common-tools/clas-analysis/src/main/java/org/jlab/analysis/postprocess/RebuildScalers.java
+++ b/common-tools/clas-analysis/src/main/java/org/jlab/analysis/postprocess/RebuildScalers.java
@@ -101,14 +101,19 @@ public class RebuildScalers {
                     runScalerBank = ds.createRunBank(writer.getSchemaFactory());
                     helScalerBank = ds.createHelicityBank(writer.getSchemaFactory());
                     
-                    // the scaler banks always are slightly after the helicity changes, so
-                    // assign the previous (delay-corrected) helicity state to this scaler reading:
-                    helScalerBank.putByte("helicity",0,helSeq.search(event,-1).value());
-                    if (helSeq.getHalfWavePlate(event))
-                        helScalerBank.putByte("helicityRaw",0,(byte)(-1*helSeq.search(event,-1).value()));
-                    else
-                        helScalerBank.putByte("helicityRaw",0,helSeq.search(event,-1).value());
-                   
+                    // the scaler banks always are slightly after the helicity changes,
+                    // so assign the previous (delay-corrected) helicity state to the
+                    // last scaler reading and then walk backwards:
+                    for (int ii=0; ii<helScalerBank.getRows(); ii++) {
+                        final int row = helScalerBank.getRows() - ii - 1;
+                        final int offset = ii - 1;
+                        helScalerBank.putByte("helicity",row,helSeq.search(event,offset).value());
+                        if (helSeq.getHalfWavePlate(event))
+                            helScalerBank.putByte("helicityRaw",0,(byte)(-1*helSeq.search(event,offset).value()));
+                        else
+                            helScalerBank.putByte("helicityRaw",0,helSeq.search(event,offset).value());
+                    }
+
                     // put modified HEL/RUN::scaler back in the event:
                     event.write(runScalerBank);
                     event.write(helScalerBank);

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/CLASDecoder4.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/CLASDecoder4.java
@@ -592,20 +592,22 @@ public class CLASDecoder4 {
      */
     public List<Bank> createReconScalerBanks(Event event){
 
+        List<Bank> ret = new ArrayList<>();
+
         // abort if run number corresponds to simulation:
-        if (this.detectorDecoder.getRunNumber() < 1000) return null;
+        if (this.detectorDecoder.getRunNumber() < 1000) return ret;
 
         // abort if we don't know about the required banks:
-        if(schemaFactory.hasSchema("RUN::config")==false) return null;
-        if(schemaFactory.hasSchema("RAW::scaler")==false) return null;
-        if(schemaFactory.hasSchema("RUN::scaler")==false) return null;
+        if(schemaFactory.hasSchema("RUN::config")==false) return ret;
+        if(schemaFactory.hasSchema("RAW::scaler")==false) return ret;
+        if(schemaFactory.hasSchema("RUN::scaler")==false) return ret;
 
         // retrieve necessary input banks, else abort:
         Bank configBank = new Bank(schemaFactory.getSchema("RUN::config"),1);
         Bank rawScalerBank = new Bank(schemaFactory.getSchema("RAW::scaler"),1);
         event.read(configBank);
         event.read(rawScalerBank);
-        if (configBank.getRows()<1 || rawScalerBank.getRows()<1) return null;
+        if (configBank.getRows()<1 || rawScalerBank.getRows()<1) return ret;
 
         // retrieve fcup/slm calibrations from slm:
         IndexedTable fcupTable = this.detectorDecoder.scalerManager.
@@ -626,9 +628,10 @@ public class CLASDecoder4 {
         }
         catch (Exception e) {
             // abort if no RCDB access (e.g. offsite)
-            return null;
+            return ret;
         }
-        return DaqScalers.createBanks(schemaFactory,rawScalerBank,fcupTable,slmTable,helTable,rst,uet);
+        ret.addAll(DaqScalers.createBanks(schemaFactory,rawScalerBank,fcupTable,slmTable,helTable,rst,uet));
+        return ret;
     }
     
     public Bank createBonusBank(){

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/CLASDecoder4.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/CLASDecoder4.java
@@ -612,6 +612,8 @@ public class CLASDecoder4 {
                 getConstants(this.detectorDecoder.getRunNumber(),"/runcontrol/fcup");
         IndexedTable slmTable = this.detectorDecoder.scalerManager.
                 getConstants(this.detectorDecoder.getRunNumber(),"/runcontrol/slm");
+        IndexedTable helTable = this.detectorDecoder.scalerManager.
+                getConstants(this.detectorDecoder.getRunNumber(),"/runcontrol/helicity");
 
         // get unix event time (in seconds), and convert to Java's date (via milliseconds):
         Date uet=new Date(configBank.getInt("unixtime",0)*1000L);
@@ -626,7 +628,7 @@ public class CLASDecoder4 {
             // abort if no RCDB access (e.g. offsite)
             return null;
         }
-        return DaqScalers.createBanks(schemaFactory,rawScalerBank,fcupTable,slmTable,rst,uet);
+        return DaqScalers.createBanks(schemaFactory,rawScalerBank,fcupTable,slmTable,helTable,rst,uet);
     }
     
     public Bank createBonusBank(){

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/CLASDecoder4.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/CLASDecoder4.java
@@ -590,7 +590,7 @@ public class CLASDecoder4 {
      * @param event
      * @return 
      */
-    public Bank[] createReconScalerBanks(Event event){
+    public List<Bank> createReconScalerBanks(Event event){
 
         // abort if run number corresponds to simulation:
         if (this.detectorDecoder.getRunNumber() < 1000) return null;
@@ -833,15 +833,12 @@ public class CLASDecoder4 {
                     
                     if(rawScaler.getRows()>0) scalerEvent.write(rawScaler);
                     if(rawRunConf.getRows()>0) scalerEvent.write(rawRunConf);
-                    
-                    Bank[] scalers = decoder.createReconScalerBanks(decodedEvent);
-                    if (scalers != null) {
-                        for (Bank b : scalers) {
-                            decodedEvent.write(b);
-                            scalerEvent.write(b);
-                        }
+
+                    for (Bank b : decoder.createReconScalerBanks(decodedEvent)) {
+                        decodedEvent.write(b);
+                        scalerEvent.write(b);
                     }
-                    
+
                     if (epics!=null) {
                         decodedEvent.write(epics);
                         scalerEvent.write(epics);

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/DetectorEventDecoder.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/DetectorEventDecoder.java
@@ -76,7 +76,7 @@ public class DetectorEventDecoder {
         tablesFitter = Arrays.asList(new String[]{"/daq/fadc/clasdev/htcc"});
         translationManager.init(keysTrans,tablesTrans);
         fitterManager.init(keysFitter, tablesFitter);
-        scalerManager.init(Arrays.asList(new String[]{"/runcontrol/fcup","/runcontrol/slm","/runcontrol/hwp"}));
+        scalerManager.init(Arrays.asList(new String[]{"/runcontrol/fcup","/runcontrol/slm","/runcontrol/hwp","/runcontrol/helicity"}));
     }
 
     public final void initDecoder(){

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/DetectorEventDecoder.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/DetectorEventDecoder.java
@@ -100,7 +100,7 @@ public class DetectorEventDecoder {
         });
         fitterManager.init(keysFitter, tablesFitter);
 
-        scalerManager.init(Arrays.asList(new String[]{"/runcontrol/fcup","/runcontrol/slm","/runcontrol/hwp"}));
+        scalerManager.init(Arrays.asList(new String[]{"/runcontrol/fcup","/runcontrol/slm","/runcontrol/hwp","/runcontrol/helicity"}));
     }
 
     /**

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/HelicityBit.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/HelicityBit.java
@@ -30,10 +30,27 @@ public enum HelicityBit {
     }
 
     public static HelicityBit getFlipped(HelicityBit bit) {
-        if (bit==PLUS) return MINUS;
-        if (bit==MINUS) return PLUS;
-        if (bit==DNE) return DNE;
-        return UDF;
+        switch (bit) {
+            case PLUS:
+                return MINUS;
+            case MINUS:
+                return PLUS;
+            case DNE:
+                return DNE;
+            default:
+                return UDF;
+        }
     }
 
+    public static HelicityBit createFromRawBit(byte bit) {
+        switch (bit) {
+            case 0:
+                return MINUS;
+            case 1:
+                return PLUS;
+            default:
+                return UDF;
+        }
+        
+    }
 }

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/HelicityInterval.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/HelicityInterval.java
@@ -10,6 +10,8 @@ public enum HelicityInterval {
     TSTABLE,
     UDF;
 
+    private static final double tolerance = 0.1;
+
     /**
      * Determine whether the clock looks more like tsettle or tstable intervals.
      * All three just need to be in the same units.
@@ -18,19 +20,27 @@ public enum HelicityInterval {
      * @param tstable
      * @return the type of helicity interval 
      */
-    public static HelicityInterval create(double clock, double tsettle, double tstable) {
-        if (clock < 0) return UDF;
-        final double tdiff = tsettle - tstable;
-        if (Math.abs(clock - tsettle) < tdiff/4) {
-            return TSETTLE;
-        }
-        else if (Math.abs(clock - tstable) < tdiff/4) {
-            return TSTABLE;
-        }
-        else {
+    public static HelicityInterval createStrict(double clock, double tsettle, double tstable) {
+        if (clock < 0) {
             return UDF;
         }
+        if (Math.abs(clock-tsettle)/tsettle < tolerance) {
+            return TSETTLE;
+        }
+        if (Math.abs(clock-tstable)/tstable < tolerance) {
+            return TSTABLE;
+        }
+        return UDF;
     }
 
+    public static HelicityInterval createLoose(double clock, double tsettle, double tstable) {
+        if (clock < 0) {
+            return UDF;
+        }
+        if (Math.abs(clock-tsettle)/tsettle < tolerance) {
+            return TSETTLE;
+        }
+        return TSTABLE;
+    }
 }
 

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/HelicityInterval.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/HelicityInterval.java
@@ -4,21 +4,22 @@ package org.jlab.detector.helicity;
  *
  * @author baltzell
  */
-public enum HelicityPeriod {
+public enum HelicityInterval {
 
     TSETTLE,
     TSTABLE,
     UDF;
 
     /**
-     * Determine whether the clock looks more like tsettle or tstable periods.
+     * Determine whether the clock looks more like tsettle or tstable intervals.
      * All three just need to be in the same units.
      * @param clock
      * @param tsettle
      * @param tstable
-     * @return the type of helicity period 
+     * @return the type of helicity interval 
      */
-    public static HelicityPeriod create(double clock, double tsettle, double tstable) {
+    public static HelicityInterval create(double clock, double tsettle, double tstable) {
+        if (clock < 0) return UDF;
         final double tdiff = tsettle - tstable;
         if (Math.abs(clock - tsettle) < tdiff/4) {
             return TSETTLE;

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/HelicityPeriod.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/HelicityPeriod.java
@@ -1,0 +1,36 @@
+package org.jlab.detector.helicity;
+
+/**
+ *
+ * @author baltzell
+ */
+public class HelicityPeriod {
+    
+    public enum Period {
+        TSETTLE,
+        TSTABLE,
+        UDF
+    };
+
+    /**
+     * Determine whether the clock looks more like tsettle or tstable periods.
+     * @param clock
+     * @param tsettle
+     * @param tstable
+     * @return the type of helicity period 
+     */
+    public static Period getHelicityPeriod(double clock, double tsettle, double tstable) {
+        final double tdiff = tsettle - tstable;
+        if (Math.abs(clock - tsettle) < tdiff/4) {
+            return Period.TSETTLE;
+        }
+        else if (Math.abs(clock - tstable) < tdiff/4) {
+            return Period.TSTABLE;
+        }
+        else {
+            return Period.UDF;
+        }
+    }
+
+}
+

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/HelicityPeriod.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/HelicityPeriod.java
@@ -4,31 +4,30 @@ package org.jlab.detector.helicity;
  *
  * @author baltzell
  */
-public class HelicityPeriod {
-    
-    public enum Period {
-        TSETTLE,
-        TSTABLE,
-        UDF
-    };
+public enum HelicityPeriod {
+
+    TSETTLE,
+    TSTABLE,
+    UDF;
 
     /**
      * Determine whether the clock looks more like tsettle or tstable periods.
+     * All three just need to be in the same units.
      * @param clock
      * @param tsettle
      * @param tstable
      * @return the type of helicity period 
      */
-    public static Period getHelicityPeriod(double clock, double tsettle, double tstable) {
+    public static HelicityPeriod create(double clock, double tsettle, double tstable) {
         final double tdiff = tsettle - tstable;
         if (Math.abs(clock - tsettle) < tdiff/4) {
-            return Period.TSETTLE;
+            return TSETTLE;
         }
         else if (Math.abs(clock - tstable) < tdiff/4) {
-            return Period.TSTABLE;
+            return TSTABLE;
         }
         else {
-            return Period.UDF;
+            return UDF;
         }
     }
 

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScaler.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScaler.java
@@ -1,7 +1,6 @@
 package org.jlab.detector.scalers;
 
 import org.jlab.utils.groups.IndexedTable;
-import org.jlab.detector.helicity.HelicityPeriod;
 
 public class DaqScaler {
 
@@ -44,18 +43,10 @@ public class DaqScaler {
     public double getBeamChargeSLM() { return beamChargeSLM; }
     public double getBeamChargeGatedSLM() { return beamChargeGatedSLM; }
 
-    /**
-     * Determine whether the clock looks more like tsettle or tstable periods.
-     * @param clock
-     * @param helTable /runcontrol/helicity CCDB table
-     * @return the type of helicity period 
-     */
-    public HelicityPeriod getHelicityPeriod(long clock, IndexedTable helTable) {
-        final double clockSeconds = (double)clock / this.clockFreq;
-        // these guys are in microseconds in CCDB, convert them to seconds:
-        final double tsettleSeconds = 1E6 * helTable.getDoubleValue("tsettle",0,0,0);
-        final double tstableSeconds = 1E6 * helTable.getDoubleValue("tstable",0,0,0);
-        return HelicityPeriod.create(clockSeconds, tstableSeconds, tsettleSeconds);
+    public enum Gating {
+        GATED,
+        UNGATED,
+        UDF;
     }
 
     /**

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScaler.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScaler.java
@@ -44,23 +44,18 @@ public class DaqScaler {
     public double getBeamChargeSLM() { return beamChargeSLM; }
     public double getBeamChargeGatedSLM() { return beamChargeGatedSLM; }
 
-    public enum Gating {
-        GATED,
-        UNGATED
-    }
-
     /**
      * Determine whether the clock looks more like tsettle or tstable periods.
      * @param clock
      * @param helTable /runcontrol/helicity CCDB table
      * @return the type of helicity period 
      */
-    public HelicityPeriod.Period getHelicityPeriod(long clock, IndexedTable helTable) {
+    public HelicityPeriod getHelicityPeriod(long clock, IndexedTable helTable) {
         final double clockSeconds = (double)clock / this.clockFreq;
         // these guys are in microseconds in CCDB, convert them to seconds:
         final double tsettleSeconds = 1E6 * helTable.getDoubleValue("tsettle",0,0,0);
         final double tstableSeconds = 1E6 * helTable.getDoubleValue("tstable",0,0,0);
-        return HelicityPeriod.getHelicityPeriod(clockSeconds, tstableSeconds, tsettleSeconds);
+        return HelicityPeriod.create(clockSeconds, tstableSeconds, tsettleSeconds);
     }
 
     /**

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScaler.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScaler.java
@@ -26,7 +26,7 @@ public class DaqScaler {
     public final double getLivetimeClock() { return (double)this.gatedClock / this.clock; }
     public final double getLivetimeFcup() {return (double)this.gatedFcup / this.fcup; } 
     public final double getLivetimeSLM() {return (double)this.gatedSlm / this.slm; } 
-       
+
     protected double beamCharge=0;
     protected double beamChargeGated=0;
     protected double beamChargeSLM=0;
@@ -45,7 +45,21 @@ public class DaqScaler {
 
     @Override
     public String toString() {
-        return String.format("%d %d %d %d %d %d",fcup,clock,slm,gatedFcup,gatedClock,gatedSlm);
+        return String.format("c=%d/%d f=%d/%d s=%d/%d",clock,gatedClock,fcup,gatedFcup,slm,gatedSlm);
+    }
+
+    /**
+     * Add raw values from another scaler reading to this one.
+     * Note, corresponding beam charges will need to be calibrated.
+     * @param other 
+     */
+    public void add(DaqScaler other) {
+        this.fcup += other.fcup;
+        this.slm += other.slm;
+        this.clock += other.clock;
+        this.gatedFcup += other.gatedFcup;
+        this.gatedClock += other.gatedClock;
+        this.gatedSlm += other.gatedSlm;
     }
 
     /**
@@ -83,7 +97,7 @@ public class DaqScaler {
             }
         }
     }
-   
+
     /**
      * Use the scaler's own clock to get dwell and live-dwell times
      * @param fcupTable /runcontrol/fcup CCDB table

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScaler.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScaler.java
@@ -43,6 +43,11 @@ public class DaqScaler {
     public double getBeamChargeSLM() { return beamChargeSLM; }
     public double getBeamChargeGatedSLM() { return beamChargeGatedSLM; }
 
+    @Override
+    public String toString() {
+        return String.format("%d %d %d %d %d %d",fcup,clock,slm,gatedFcup,gatedClock,gatedSlm);
+    }
+
     /**
      * Manually choose dwell and live-dwell times, e.g. if clock rolls over.
      * @param fcupTable /runcontrol/fcup CCDB table

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScaler.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScaler.java
@@ -43,12 +43,6 @@ public class DaqScaler {
     public double getBeamChargeSLM() { return beamChargeSLM; }
     public double getBeamChargeGatedSLM() { return beamChargeGatedSLM; }
 
-    public enum Gating {
-        GATED,
-        UNGATED,
-        UDF;
-    }
-
     /**
      * Manually choose dwell and live-dwell times, e.g. if clock rolls over.
      * @param fcupTable /runcontrol/fcup CCDB table

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScaler.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScaler.java
@@ -50,7 +50,7 @@ public class DaqScaler {
 
     /**
      * Add raw values from another scaler reading to this one.
-     * Note, corresponding beam charges will need to be calibrated.
+     * Note, "calibrate" will need to be called afterwards.
      * @param other 
      */
     public void add(DaqScaler other) {

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScalers.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScalers.java
@@ -172,9 +172,11 @@ public class DaqScalers {
     public static List<Bank> createBanks(SchemaFactory schema,Bank rawScalerBank,IndexedTable fcupTable,IndexedTable slmTable,IndexedTable helTable) {
         DaqScalers ds = DaqScalers.create(rawScalerBank,fcupTable,slmTable,helTable);
         List<Bank> ret = new ArrayList<>();
+        // only add the RUN::scaler bank if we actually got a DSC2 readout:
         if (ds.dsc2.getClock()>0 || ds.dsc2.getGatedClock()>0) {
             ret.add(ds.createRunBank(schema));
         }
+        // only add the HEL::scaler bank if we actually got a Struck readout:
         if (!ds.struck.isEmpty()) {
             ret.add(ds.createHelicityBank(schema));
         }
@@ -193,9 +195,11 @@ public class DaqScalers {
     public static List<Bank> createBanks(SchemaFactory schema,Bank rawScalerBank,IndexedTable fcupTable,IndexedTable slmTable,IndexedTable helTable,double seconds) {
         DaqScalers ds = DaqScalers.create(rawScalerBank,fcupTable,slmTable,helTable,seconds);
         List<Bank> ret = new ArrayList<>();
+        // only add the RUN::scaler bank if we actually got a DSC2 readout:
         if (ds.dsc2.getClock()>0 || ds.dsc2.getGatedClock()>0) {
             ret.add(ds.createRunBank(schema));
         }
+        // only add the HEL::scaler bank if we actually got a Struck readout:
         if (!ds.struck.isEmpty()) {
             ret.add(ds.createHelicityBank(schema));
         }

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScalers.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScalers.java
@@ -206,6 +206,16 @@ public class DaqScalers {
         return ret;
     }
 
+    /**
+     * @param rawScalerBank RAW::scaler bank
+     * @param schema bank schema
+     * @param fcupTable /runcontrol/fcup CCDB table
+     * @param slmTable /runcontrol/slm CCDB table
+     * @param helTable /runcontrol/helicity CCDB table
+     * @param rst run start time
+     * @param uet event time
+     * @return [RUN::scaler,HEL::scaler] banks
+     */
     public static List<Bank> createBanks(SchemaFactory schema,Bank rawScalerBank,IndexedTable fcupTable,IndexedTable slmTable,IndexedTable helTable,Date rst,Date uet) {
         return DaqScalers.createBanks(schema,rawScalerBank,fcupTable,slmTable,helTable,DaqScalers.getSeconds(rst,uet));
     }

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScalers.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScalers.java
@@ -97,7 +97,7 @@ public class DaqScalers {
      * @return 
      */
     public static DaqScalers create(Bank rawScalerBank,IndexedTable fcupTable,IndexedTable slmTable,IndexedTable helTable,double seconds) {
-        StruckScalers struck = StruckScalers.readAllPruned(rawScalerBank,fcupTable,slmTable,helTable);
+        StruckScalers struck = StruckScalers.read(rawScalerBank,fcupTable,slmTable,helTable);
         Dsc2Scaler dsc2 = new Dsc2Scaler(rawScalerBank,fcupTable,slmTable,seconds);
         DaqScalers ds = new DaqScalers();
         ds.dsc2 = dsc2;
@@ -140,7 +140,8 @@ public class DaqScalers {
         Bank bank = new Bank(schema.getSchema("RUN::scaler"),1);
         bank.putFloat("fcup",0,(float)this.dsc2.getBeamCharge());
         bank.putFloat("fcupgated",0,(float)this.dsc2.getBeamChargeGated());
-        bank.putFloat("livetime",0,(float)this.struck.get(this.struck.size()-1).getLivetimeClock());
+        if (this.struck.size() > 0)
+          bank.putFloat("livetime",0,(float)this.struck.get(this.struck.size()-1).getLivetimeClock());
         return bank;
     }
 

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScalers.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScalers.java
@@ -93,8 +93,8 @@ public class DaqScalers {
      * @param seconds duration between run start and current event
      * @return 
      */
-    public static DaqScalers create(Bank rawScalerBank,IndexedTable fcupTable,IndexedTable slmTable,double seconds) {
-        StruckScaler struck = new StruckScaler(rawScalerBank,fcupTable,slmTable);
+    public static DaqScalers create(Bank rawScalerBank,IndexedTable fcupTable,IndexedTable slmTable,IndexedTable helTable,double seconds) {
+        StruckScaler struck = new StruckScaler(rawScalerBank,fcupTable,slmTable,helTable);
         Dsc2Scaler dsc2 = new Dsc2Scaler(rawScalerBank,fcupTable,slmTable,seconds);
         if (dsc2.getClock()>0 || struck.getClock()>0) {
             DaqScalers ds=new DaqScalers();
@@ -113,8 +113,8 @@ public class DaqScalers {
      * @param uet unix event time
      * @return 
      */
-    public static DaqScalers create(Bank rawScalerBank,IndexedTable fcupTable,IndexedTable slmTable,Date rst, Date uet) {
-        return DaqScalers.create(rawScalerBank,fcupTable,slmTable,DaqScalers.getSeconds(rst, uet));
+    public static DaqScalers create(Bank rawScalerBank,IndexedTable fcupTable,IndexedTable slmTable,IndexedTable helTable,Date rst, Date uet) {
+        return DaqScalers.create(rawScalerBank,fcupTable,slmTable,helTable,DaqScalers.getSeconds(rst, uet));
     }
     
     /**
@@ -125,9 +125,9 @@ public class DaqScalers {
      * @param slmTable /runcontrol/slm from CCDB
      * @return  
      */
-    public static DaqScalers create(Bank rawScalerBank,IndexedTable fcupTable,IndexedTable slmTable) {
+    public static DaqScalers create(Bank rawScalerBank,IndexedTable fcupTable,IndexedTable slmTable,IndexedTable helTable) {
         Dsc2Scaler dsc2 = new Dsc2Scaler(rawScalerBank,fcupTable,slmTable);
-        return DaqScalers.create(rawScalerBank,fcupTable,slmTable,dsc2.getGatedClockSeconds());
+        return DaqScalers.create(rawScalerBank,fcupTable,slmTable,helTable,dsc2.getGatedClockSeconds());
     }
 
     /**
@@ -164,8 +164,8 @@ public class DaqScalers {
      * @param slmTable /runcontrol/slm CCDB table
      * @return [RUN::scaler,HEL::scaler] banks
      */
-    public static Bank[] createBanks(SchemaFactory schema,Bank rawScalerBank,IndexedTable fcupTable,IndexedTable slmTable) {
-        DaqScalers ds = DaqScalers.create(rawScalerBank,fcupTable,slmTable);
+    public static Bank[] createBanks(SchemaFactory schema,Bank rawScalerBank,IndexedTable fcupTable,IndexedTable slmTable,IndexedTable helTable) {
+        DaqScalers ds = DaqScalers.create(rawScalerBank,fcupTable,slmTable,helTable);
         if (ds==null) return null;
         Bank ret[] = {ds.createRunBank(schema),ds.createHelicityBank(schema)};
         return ret;
@@ -179,15 +179,15 @@ public class DaqScalers {
      * @param seconds duration between run start and current event
      * @return [RUN::scaler,HEL::scaler] banks
      */
-    public static Bank[] createBanks(SchemaFactory schema,Bank rawScalerBank,IndexedTable fcupTable,IndexedTable slmTable,double seconds) {
-        DaqScalers ds = DaqScalers.create(rawScalerBank,fcupTable,slmTable,seconds);
+    public static Bank[] createBanks(SchemaFactory schema,Bank rawScalerBank,IndexedTable fcupTable,IndexedTable slmTable,IndexedTable helTable,double seconds) {
+        DaqScalers ds = DaqScalers.create(rawScalerBank,fcupTable,slmTable,helTable,seconds);
         if (ds==null) return null;
         Bank ret[] = {ds.createRunBank(schema),ds.createHelicityBank(schema)};
         return ret;
     }
 
-    public static Bank[] createBanks(SchemaFactory schema,Bank rawScalerBank,IndexedTable fcupTable,IndexedTable slmTable,Date rst,Date uet) {
-        return DaqScalers.createBanks(schema,rawScalerBank,fcupTable,slmTable,DaqScalers.getSeconds(rst,uet));
+    public static Bank[] createBanks(SchemaFactory schema,Bank rawScalerBank,IndexedTable fcupTable,IndexedTable slmTable,IndexedTable helTable,Date rst,Date uet) {
+        return DaqScalers.createBanks(schema,rawScalerBank,fcupTable,slmTable,helTable,DaqScalers.getSeconds(rst,uet));
     }
 
 }

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScalersSequence.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScalersSequence.java
@@ -10,7 +10,6 @@ import org.jlab.jnp.hipo4.io.HipoReader;
 import org.jlab.jnp.hipo4.data.Event;
 import org.jlab.jnp.hipo4.data.Bank;
 import org.jlab.jnp.hipo4.data.SchemaFactory;
-import org.jlab.detector.scalers.DaqScalers;
 
 /**
  * For easy access to most recent scaler readout for any given event.

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/Dsc2Scaler.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/Dsc2Scaler.java
@@ -3,6 +3,17 @@ package org.jlab.detector.scalers;
 import org.jlab.jnp.hipo4.data.Bank;
 import org.jlab.utils.groups.IndexedTable;
 
+/**
+ * The DSC2 is a JLab-designed discriminator board with 2 thresholds, called TDC
+ * and TRG, with independent outputs, both gated and ungated, and corresponding
+ * VME-readable scalers.
+ * 
+ * The CLAS12 DAQ uses this board to periodically readout run-integrated scalers
+ * like the Faraday cup and SLM, for the purposes of total beam-charge measurements,
+ * and that's what this class is geared towards.
+ * 
+ * @author baltzell
+ */
 public class Dsc2Scaler extends DaqScaler{
 
     private static final boolean GATEINVERTED=true;
@@ -16,9 +27,13 @@ public class Dsc2Scaler extends DaqScaler{
     private static final int CHAN_SLM=49;
     private static final int CHAN_CLOCK=50;
 
-    public Dsc2Scaler() {}
-
-    public Dsc2Scaler(Bank bank,IndexedTable fcupTable,IndexedTable slmTable,double seconds) {
+    /**
+     * @param bank RAW::scaler bank
+     * @param fcupTable /runcontrol/fcup CCDB table
+     * @param slmTable  /runcontrol/slm CCDB table
+     * @param seconds dwell time, provided in case the clock rolls over
+     */
+    public Dsc2Scaler(Bank bank, IndexedTable fcupTable, IndexedTable slmTable, double seconds) {
 
         // the DSC2's clock is (currently) 1 MHz
         // FIXME:  use CCDB
@@ -67,7 +82,7 @@ public class Dsc2Scaler extends DaqScaler{
      * @param fcupTable /runcontrol/fcup CCDB table
      * @param slmTable  /runcontrol/slm CCDB table
      */
-    public Dsc2Scaler(Bank bank,IndexedTable fcupTable,IndexedTable slmTable) {
+    public Dsc2Scaler(Bank bank, IndexedTable fcupTable, IndexedTable slmTable) {
         this(bank,fcupTable,slmTable,1);
         this.calibrate(fcupTable,slmTable);
     }
@@ -80,7 +95,7 @@ public class Dsc2Scaler extends DaqScaler{
      * @param slmTable /runcontrol/slm CCDB table
      * @param seconds 
      */
-    protected final void calibrate(IndexedTable fcupTable,IndexedTable slmTable,double seconds) {
+    protected final void calibrate(IndexedTable fcupTable, IndexedTable slmTable, double seconds) {
         if (this.slm>0) {
             super.calibrate(fcupTable,slmTable,seconds,seconds*((double)this.gatedSlm)/this.slm);
         }

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/Dsc2Scaler.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/Dsc2Scaler.java
@@ -27,6 +27,8 @@ public class Dsc2Scaler extends DaqScaler{
     private static final int CHAN_SLM=49;
     private static final int CHAN_CLOCK=50;
 
+    public Dsc2Scaler() {}
+
     /**
      * @param bank RAW::scaler bank
      * @param fcupTable /runcontrol/fcup CCDB table

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/StruckScaler.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/StruckScaler.java
@@ -38,11 +38,36 @@ public class StruckScaler extends DaqScaler {
     private static final int CHAN_SLM_B=33;
     private static final int CHAN_CLOCK_B=34;
 
-    public enum StruckPeriod {
+    /**
+     * The input signal mapping.
+     */
+    public enum Channel {
+        FCUP,
+        SLM,
+        CLOCK,
+        UDF;
+        public static boolean equals(Channel s, int c) {
+            switch (s) {
+                case FCUP:
+                    return c==CHAN_FCUP_A || c==CHAN_FCUP_B;
+                case SLM:
+                    return c==CHAN_SLM_A || c==CHAN_SLM_B;
+                case CLOCK:
+                    return c==CHAN_CLOCK_A || c==CHAN_CLOCK_B;
+                default:
+                    return false;
+            } 
+        }
+    }
+   
+    /**
+     * The period mapping, which corresponds to helicity period.
+     */
+    public enum Period {
         A,
         B,
         UDF;
-        public static StruckPeriod create(int struckChannel) {
+        public static Period create(int struckChannel) {
             switch (struckChannel) {
                 case CHAN_FCUP_A:
                     return A;
@@ -62,24 +87,28 @@ public class StruckScaler extends DaqScaler {
         }
     }
 
-    //public class StruckHelicityPeriod {
-    //    HelicityPeriod helPeriod;
-    //    StruckPeriod struckPeriod;
-    //    public StruckHelicityPeriod(HelicityPeriod hp, StruckPeriod sp) {
-    //        this.helPeriod = hp;
-    //        this.struckPeriod = sp;
-    //    }
-    //}
-
-    public StruckScaler() {}
+    /**
+     * Determine whether the clock looks more like tsettle or tstable periods.
+     * @param clock
+     * @param helTable /runcontrol/helicity CCDB table
+     * @return the type of helicity period 
+     */
+    public HelicityPeriod getHelicityPeriod(long clock, IndexedTable helTable) {
+        final double clockSeconds = (double)clock / this.clockFreq;
+        // these guys are in microseconds in CCDB, convert them to seconds:
+        final double tsettleSeconds = 1E6 * helTable.getDoubleValue("tsettle",0,0,0);
+        final double tstableSeconds = 1E6 * helTable.getDoubleValue("tstable",0,0,0);
+        return HelicityPeriod.create(clockSeconds, tstableSeconds, tsettleSeconds);
+    }
 
     /**
      * Look for an ungated clock readout whose value corresponds to the helicity
      * tsettle period, and return it's Struck period.
      * @param bank
+     * @param helTable /runcontrol/helicity CCDB table
      * @return 
      */
-    public final StruckPeriod getStablePeriod(Bank bank, IndexedTable helTable) {
+    public final Period getStablePeriod(Bank bank, IndexedTable helTable) {
         for (int k=0; k<bank.getRows(); k++){
             if (bank.getInt("crate",k)!=CRATE) continue;
             if (bank.getInt("slot",k)!=SLOT_UNGATED) continue;
@@ -87,11 +116,11 @@ public class StruckScaler extends DaqScaler {
             if (chan==CHAN_CLOCK_A || chan==CHAN_CLOCK_B) {
                 final long clck = bank.getLong("value",k);
                 if (this.getHelicityPeriod(clck,helTable) == HelicityPeriod.TSTABLE) {
-                    return StruckPeriod.create(chan);
+                    return Period.create(chan);
                 }
             }
         }
-        return StruckPeriod.UDF;
+        return Period.UDF;
     }
 
     public StruckScaler(Bank bank,IndexedTable fcupTable, IndexedTable slmTable, IndexedTable helTable) {
@@ -99,56 +128,72 @@ public class StruckScaler extends DaqScaler {
         // the STRUCK's clock is 1 MHz
         this.clockFreq = 1e6;
 
-        // Here we're going to assume the stable period is the same Struck period
-        // throughout a single readout.  Almost always correct ...
+        // Here we're going to assume the stable period is the same Struck
+        // period throughout a single readout.  Almost always correct ...
         // FIXME
-        StruckPeriod stablePeriod = this.getStablePeriod(bank, helTable);
+        Period stablePeriod = this.getStablePeriod(bank, helTable);
 
         // Couldn't find an ungated clock in the stable period, so there's
         // nothing useful we can do:
-        if (stablePeriod == StruckPeriod.UDF) return;
+        if (stablePeriod == Period.UDF) return;
         
         for (int k=0; k<bank.getRows(); k++){
 
+            // If it ain't the right crate, ignore it:
             if (bank.getInt("crate",k)!=CRATE) continue;
 
-            // If the period doesn't correspond to tstable, ignore it:
-            StruckPeriod thisPeriod = StruckPeriod.create(bank.getInt("channel",k));
+            // Determine the tsettle/tstable period for this bank row:
+            Period thisPeriod = Period.create(bank.getInt("channel",k));
+
+            // If it doesn't correspond to tstable, ignore it:
             if (thisPeriod != stablePeriod) continue;
 
-            if (bank.getInt("slot",k)==SLOT_GATED) {
-                switch (bank.getInt("channel",k)) {
-                    case CHAN_FCUP_A:
+            // Determine the gating for this bank row, and, if undefined,
+            // just ignore it:
+            Gating gating = Gating.UDF;
+            switch (bank.getInt("slot",k)) {
+                case SLOT_GATED:
+                    gating = Gating.GATED;
+                    break;
+                case SLOT_UNGATED:
+                    gating = Gating.UNGATED;
+                    break;
+                default:
+                    continue;
+            }
+
+            // Finally, do somthing useful:
+            final int chan = bank.getInt("channel",k);
+            switch (gating) {
+                case GATED:
+                    if (Channel.equals(Channel.FCUP, chan)) {
                         this.helicity = bank.getByte("helicity",k) > 0 ? POSITIVE : NEGATIVE;
                         this.quartet = bank.getByte("quartet",k)   > 0 ? POSITIVE : NEGATIVE;
                         this.gatedFcup = bank.getLong("value",k);
-                        break;
-                    case CHAN_SLM_A:
+                    }
+                    else if (Channel.equals(Channel.SLM, chan)) {
                         this.gatedSlm = bank.getLong("value",k);
-                        break;
-                    case CHAN_CLOCK_A:
+                    }
+                    else if (Channel.equals(Channel.CLOCK, chan)) {
                         this.gatedClock = bank.getLong("value",k);
-                        break;
-                    default:
-                        break;
-                }
-            }
-            else if (bank.getInt("slot",k)==SLOT_UNGATED) {
-                switch (bank.getInt("channel",k)) {
-                    case CHAN_FCUP_B:
+                    }
+                    break;
+                case UNGATED:
+                    if (Channel.equals(Channel.FCUP, chan)) {
                         this.fcup = bank.getLong("value",k);
-                        break;
-                    case CHAN_SLM_B:
+                    }
+                    else if (Channel.equals(Channel.SLM, chan)) {
                         this.slm = bank.getLong("value",k);
-                        break;
-                    case CHAN_CLOCK_B:
+                    }
+                    else if (Channel.equals(Channel.CLOCK, chan)) {
                         this.clock = bank.getLong("value",k);
-                        break;
-                    default:
-                        break;
-                }
+                    }
+                    break;
+                default:
+                    break;
             }
         }
+
         if (GATEINVERTED) {
             gatedSlm = slm - gatedSlm;
             gatedFcup = fcup - gatedFcup;

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/StruckScaler.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/StruckScaler.java
@@ -3,6 +3,16 @@ package org.jlab.detector.scalers;
 import org.jlab.jnp.hipo4.data.Bank;
 import org.jlab.utils.groups.IndexedTable;
 
+/**
+ * The Struck is a multi-channel scaler that can buffer many readings over very
+ * short dwell times, advanced by and latched to input control signals.
+ * 
+ * The CLAS12 DAQ uses this device to readout helicity-latched counts for the
+ * purpose of beam-spin asymmetry measurements, and that's what this class is
+ * geared towards.
+ * 
+ * @author baltzell
+ */
 public class StruckScaler extends DaqScaler {
 
     private static final boolean GATEINVERTED=false;

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/StruckScaler.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/StruckScaler.java
@@ -226,7 +226,9 @@ public class StruckScaler extends DaqScaler {
     /**
      * Get all the "good" helicity intervals readout in one RAW::scaler bank.
      * Here "good" means tstable, which requires an existing clock reading that
-     * also looks like the tstable helicity interval.
+     * also looks like the tstable helicity interval.  Note, this should also
+     * get rid of any cases where things didn't get full initialized and resulted
+     * in -1 values in HEL::scaler.
      * @param bank a RAW::scaler bank
      * @param fcupTable /runcontrol/fcup CCDB table
      * @param slmTable /runcontrol/slm CCDB table

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/StruckScaler.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/StruckScaler.java
@@ -48,6 +48,11 @@ public class StruckScaler extends DaqScaler {
         return this.interval;
     }
 
+    @Override
+    public String toString() {
+        return String.format("i=%s h=%d q=%d %s",this.interval,this.helicity.value(),this.quartet.value(),super.toString());
+    }
+
     /**
      * Convenience for mapping channel number in RAW::scaler to input signal.
      */
@@ -167,6 +172,7 @@ public class StruckScaler extends DaqScaler {
      * @param slmTable /runcontrol/slm CCDB table
      * @param helTable /runcontrol/helicity CCDB table
      */
+    @Deprecated
     public StruckScaler(Bank bank,IndexedTable fcupTable, IndexedTable slmTable, IndexedTable helTable) {
 
         // the STRUCK's clock is 1 MHz
@@ -197,8 +203,8 @@ public class StruckScaler extends DaqScaler {
             switch (bank.getInt("slot",k)) {
                 case SLOT_GATED:
                     if (Input.equals(Input.FCUP, chan)) {
-                        this.helicity = HelicityBit.create(bank.getByte("helicity",k));
-                        this.quartet = HelicityBit.create(bank.getByte("quartet",k));
+                        this.helicity = HelicityBit.createFromRawBit(bank.getByte("helicity",k));
+                        this.quartet = HelicityBit.createFromRawBit(bank.getByte("quartet",k));
                         this.gatedFcup = bank.getLong("value",k);
                     }
                     else if (Input.equals(Input.SLM, chan)) {

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/StruckScaler.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/StruckScaler.java
@@ -12,6 +12,9 @@ import org.jlab.detector.helicity.HelicityInterval;
  * The CLAS12 DAQ uses this device to readout helicity-latched counts for the
  * purpose of beam-spin asymmetry measurements, and that's what this class is
  * geared towards.
+ *
+ * At some point over the years, readout patterns changed and this class alone
+ * is no longer sufficient.  See StruckScalers instead.
  * 
  * @author baltzell
  */
@@ -39,7 +42,7 @@ public class StruckScaler extends DaqScaler {
     private static final int CHAN_SLM_B=33;
     private static final int CHAN_CLOCK_B=34;
 
-    private Interval interval;
+    protected Interval interval;
 
     public void setInterval(Interval intvl) {
         this.interval = intvl;
@@ -124,9 +127,9 @@ public class StruckScaler extends DaqScaler {
     public HelicityInterval getHelicityInterval(long clock, IndexedTable helTable) {
         final double clockSeconds = (double)clock / this.clockFreq;
         // these guys are in microseconds in CCDB, convert them to seconds:
-        final double tsettleSeconds = 1E6 * helTable.getDoubleValue("tsettle",0,0,0);
-        final double tstableSeconds = 1E6 * helTable.getDoubleValue("tstable",0,0,0);
-        return HelicityInterval.create(clockSeconds, tstableSeconds, tsettleSeconds);
+        final double tsettleSeconds = 1E-6 * helTable.getDoubleValue("tsettle",0,0,0);
+        final double tstableSeconds = 1E-6 * helTable.getDoubleValue("tstable",0,0,0);
+        return HelicityInterval.createLoose(clockSeconds, tsettleSeconds, tstableSeconds);
     }
     
     /**
@@ -137,7 +140,6 @@ public class StruckScaler extends DaqScaler {
     public HelicityInterval getHelicityInterval(IndexedTable helTable) {
         return this.getHelicityInterval(this.clock, helTable);
     }
-
 
     /**
      * Look for the first ungated clock readout whose value corresponds to the
@@ -180,7 +182,6 @@ public class StruckScaler extends DaqScaler {
 
         // Here we're going to assume the stable period is the same Struck
         // period throughout a single readout.  Almost always correct ...
-        // FIXME
         Interval stablePeriod = this.getStableInterval(bank, helTable);
 
         // Couldn't find an ungated clock in the stable period, so there's

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/StruckScalers.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/StruckScalers.java
@@ -1,0 +1,122 @@
+package org.jlab.detector.scalers;
+
+import java.util.ArrayList;
+import org.jlab.detector.helicity.HelicityBit;
+import org.jlab.detector.helicity.HelicityInterval;
+import org.jlab.jnp.hipo4.data.Bank;
+import org.jlab.utils.groups.IndexedTable;
+import org.jlab.detector.scalers.StruckScaler.Interval;
+import org.jlab.detector.scalers.StruckScaler.Input;
+
+/**
+ *
+ * This is an extension of the StruckScaler class to support multiple tstable
+ * helicity intervals in a single RAW::scaler bank.
+ * 
+ * @author baltzell
+ */
+public class StruckScalers extends ArrayList<StruckScaler> {
+
+    @Override
+    public String toString() {
+        String ret = new String();
+        for (StruckScaler ss : this) {
+            ret += ss.toString();
+            ret += "\n"+super.toString();
+        }
+        return ret;
+    }
+
+    /**
+     * Get all intervals readout in one RAW::scaler bank.
+     * @param bank a RAW::scaler bank
+     * @param fcupTable /runcontrol/fcup CCDB table
+     * @param slmTable /runcontrol/slm CCDB table
+     * @param helTable /runcontrol/helicity CCDB table
+     * @return all tstable intervals 
+     */
+    public static StruckScalers readAll(Bank bank, IndexedTable fcupTable, IndexedTable slmTable, IndexedTable helTable) {
+
+        StruckScalers ret = new StruckScalers();
+        StruckScaler reading = new StruckScaler();
+
+        for (int k=0; k<bank.getRows(); ++k) {
+
+            if (bank.getInt("crate",k) != StruckScaler.CRATE) continue;
+
+            final int chan = bank.getInt("channel",k);
+            final Interval intvl = Interval.create(chan);
+
+            // Found a new interval:
+            if (ret.isEmpty() || intvl != ret.get(ret.size()-1).getInterval()) {
+                reading = new StruckScaler();
+                reading.setInterval(intvl);
+                ret.add(reading);
+            }
+
+            switch (bank.getInt("slot",k)) {
+                case StruckScaler.SLOT_GATED:
+                    if (Input.equals(Input.FCUP, chan)) {
+                        reading.helicity = HelicityBit.create(bank.getByte("helicity",k));
+                        reading.quartet = HelicityBit.create(bank.getByte("quartet",k));
+                        reading.gatedFcup = bank.getLong("value",k);
+                    }
+                    else if (Input.equals(Input.SLM, chan)) {
+                        reading.gatedSlm = bank.getLong("value",k);
+                    }
+                    else if (Input.equals(Input.CLOCK, chan)) {
+                        reading.gatedClock = bank.getLong("value",k);
+                    }
+                    break;
+                case StruckScaler.SLOT_UNGATED:
+                    if (Input.equals(Input.FCUP, chan)) {
+                        reading.fcup = bank.getLong("value",k);
+                    }
+                    else if (Input.equals(Input.SLM, chan)) {
+                        reading.slm = bank.getLong("value",k);
+                    }
+                    else if (Input.equals(Input.CLOCK, chan)) {
+                        reading.clock = bank.getLong("value",k);
+                    }
+                    break;
+                default:
+                    break;
+            }
+            
+        }
+
+        // go back and "calibrate" all of them, e.g. convert to beam charge and livetime:
+        for (StruckScaler ss : ret) { 
+            ss.calibrate(fcupTable,slmTable);
+        }
+
+        return ret;
+    }
+
+    /**
+     * Get all the "good" helicity intervals readout in one RAW::scaler bank.
+     * Here "good" means tstable, which requires an existing clock reading that
+     * also looks like the tstable helicity interval.  Note, this should also
+     * get rid of any cases where things didn't get fully initialized and resulted
+     * in -1 values in HEL::scaler.
+     * @param bank a RAW::scaler bank
+     * @param fcupTable /runcontrol/fcup CCDB table
+     * @param slmTable /runcontrol/slm CCDB table
+     * @param helTable /runcontrol/helicity CCDB table
+     * @return all tstable intervals 
+     */
+    public static StruckScalers readAllPruned(Bank bank, IndexedTable fcupTable, IndexedTable slmTable, IndexedTable helTable) {
+        StruckScalers ret = StruckScalers.readAll(bank, fcupTable, slmTable, helTable);
+        for (StruckScaler ss : ret) {
+            if (ss.getHelicityInterval(helTable) != HelicityInterval.TSTABLE) {
+                ret.remove(ss);
+            }
+        }
+        return ret;
+    }
+
+    public static void main(String[] args) {
+        StruckScalers s = new StruckScalers();
+        System.out.println(s);
+    }
+}


### PR DESCRIPTION
1. Support quirks in the Struck scaler readout scheme for `HEL::scaler`
   - do not rely on a consistent interval mapping, instead rely on clock to differentiate tsettle/tstable
       - this became an issue at least during RG-C due to false advances, maybe related to the inclusion of the new helicity decoder board in the signal path
       - merging intervals created from false advances was considered but deemed not worthwhile, at least for now, instead we just keep both, see next item
   - support an arbitrary number of intervals in a single event
       - previously only one tstable (and tsettle) was assumed, now we keep every readout that does **_not_** look like a tsettle, based on the clock
       - in the case of multi-interval readouts, gated/ungated readings from the same interval are not contiguous, and those are now disentangled
    -  closes #945 
2. Only create `RUN::scaler` if the DSC2 readout is really present
    - this started happening during RG-M when the readout scheme changed to workaround broken helicity signals, and then scaler readouts no longer always contained both Struck and DSC2 scalers
    - closes #863

**All this affects only `RUN::scaler` and `HEL::scaler` banks, while the `RAW::scaler` bank, which can only be made during decoding, is unaffected and still essentially a straight copy from EVIO.**