### PR TITLE
Switch to gemc 5.1 for EB tests

### DIFF
--- a/validation/advanced-tests/run-eb-tests.sh
+++ b/validation/advanced-tests/run-eb-tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 webDir=http://clasweb.jlab.org/clas12offline/distribution/coatjava/validation_files/eb
-webVersion=5.0-fid-r11
+webVersion=5.1-fid-r11
 webDir=$webDir/$webVersion
 
 # coatjava must already be built at ../../coatjava/


### PR DESCRIPTION
This avoids the magic bank production in older C++ HIPO versions that perturbs the truth-matching service and fill up the CI logs.  Those test files are always here:  https://clasweb.jlab.org/clas12offline/distribution/coatjava/validation_files/eb/
