### PR TITLE
Avod trans step size0

### DIFF
--- a/reconstruction/dc/src/main/java/org/jlab/rec/dc/track/fit/StateVecsDoca.java
+++ b/reconstruction/dc/src/main/java/org/jlab/rec/dc/track/fit/StateVecsDoca.java
@@ -79,7 +79,7 @@ public class StateVecsDoca {
 
         while(Math.signum(Zf - Z[i]) *z<Math.signum(Zf - Z[i]) *Zf) {
             z = fVec.z;
-            if(z == Z[f]) break;
+            if(z == Zf) break;
 
             //LOGGER.log(Level.FINE, " RK step num "+(j+1)+" = "+(float)s+" nSteps = "+nSteps);
             double x =  fVec.x;

--- a/reconstruction/dc/src/main/java/org/jlab/rec/dc/track/fit/StateVecsDoca.java
+++ b/reconstruction/dc/src/main/java/org/jlab/rec/dc/track/fit/StateVecsDoca.java
@@ -78,10 +78,12 @@ public class StateVecsDoca {
         double BatMeas = iVec.B;
 
         while(Math.signum(Zf - Z[i]) *z<Math.signum(Zf - Z[i]) *Zf) {
+            z = fVec.z;
+            if(z == Z[f]) break;
+
             //LOGGER.log(Level.FINE, " RK step num "+(j+1)+" = "+(float)s+" nSteps = "+nSteps);
             double x =  fVec.x;
             double y =  fVec.y;
-            z = fVec.z;
             double tx = fVec.tx;
             double ty = fVec.ty;
             double Q =  fVec.Q;
@@ -169,10 +171,12 @@ public class StateVecsDoca {
         double BatMeas = iVec.B;
 
         while(Math.signum(Z[f] - Z[i]) *z<Math.signum(Z[f] - Z[i]) *Z[f]) {
+            z = fVec.z;
+            if(z == Z[f]) break;
+
             //LOGGER.log(Level.FINE, " RK step num "+(j+1)+" = "+(float)s+" nSteps = "+nSteps);
             double x =  fVec.x;
             double y =  fVec.y;
-            z = fVec.z;
             double tx = fVec.tx;
             double ty = fVec.ty;
             double Q =  fVec.Q;


### PR DESCRIPTION
Step size of the last RK step from one measurement layer to next layer is always 0.
For such RK step with step size of 0, RK calculation is taken, but scaled by 0.
Therefore, it is safe update. The update will not change results at all, but will save some running time.
For transport, percentage of saved time is about # of measurement layers / total of steps from first layer to last layer.