### PR TITLE
Address time zone issues for run duration calculations

### DIFF
--- a/common-tools/clas-analysis/src/main/java/org/jlab/analysis/postprocess/RebuildScalers.java
+++ b/common-tools/clas-analysis/src/main/java/org/jlab/analysis/postprocess/RebuildScalers.java
@@ -1,7 +1,6 @@
 package org.jlab.analysis.postprocess;
 
 import java.sql.Time;
-import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.List;
 import org.jlab.detector.calib.utils.ConstantsManager;
@@ -28,8 +27,6 @@ public class RebuildScalers {
     static final String CCDB_SLM_TABLE="/runcontrol/slm";
     static final String CCDB_HEL_TABLE="/runcontrol/helicity";
     
-    static final ZoneId zoneId = ZoneId.of( "America/New_York" );
-
     public static void main(String[] args) {
 
         DefaultLogger.debug();
@@ -101,7 +98,7 @@ public class RebuildScalers {
                     Time rst = rcdb.getTime("run_start_time");
                     long uet = runConfigBank.getInt("unixtime",0);
 
-                    DaqScalers ds = DaqScalers.create(rawScalerBank, ccdb_fcup, ccdb_slm, ccdb_hel, zoneId, rst, uet);
+                    DaqScalers ds = DaqScalers.create(rawScalerBank, ccdb_fcup, ccdb_slm, ccdb_hel, rst, uet);
                     runScalerBank = ds.createRunBank(writer.getSchemaFactory());
                     helScalerBank = ds.createHelicityBank(writer.getSchemaFactory());
                    

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/CLASDecoder4.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/CLASDecoder4.java
@@ -5,7 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import java.sql.Time;
-import java.util.Date;
+import java.time.ZoneId;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.jlab.detector.base.DetectorDescriptor;
@@ -46,8 +46,9 @@ public class CLASDecoder4 {
     private HipoDataEvent               hipoEvent = null;
     private boolean              isRunNumberFixed = false;
     private int                  decoderDebugMode = 0;
-    private SchemaFactory        schemaFactory = new SchemaFactory();
-
+    private SchemaFactory           schemaFactory = new SchemaFactory();
+    private ZoneId                       timeZone = ZoneId.of( "America/New_York" );
+    
     public CLASDecoder4(boolean development){
         codaDecoder = new CodaEventDecoder();
         detectorDecoder = new DetectorEventDecoder(development);
@@ -617,8 +618,8 @@ public class CLASDecoder4 {
         IndexedTable helTable = this.detectorDecoder.scalerManager.
                 getConstants(this.detectorDecoder.getRunNumber(),"/runcontrol/helicity");
 
-        // get unix event time (in seconds), and convert to Java's date (via milliseconds):
-        Date uet=new Date(configBank.getInt("unixtime",0)*1000L);
+        // get unix event time (in seconds):
+        long uet = configBank.getInt("unixtime",0);
 
         // retrieve RCDB run start time:
         Time rst;
@@ -630,7 +631,7 @@ public class CLASDecoder4 {
             // abort if no RCDB access (e.g. offsite)
             return ret;
         }
-        ret.addAll(DaqScalers.createBanks(schemaFactory,rawScalerBank,fcupTable,slmTable,helTable,rst,uet));
+        ret.addAll(DaqScalers.createBanks(schemaFactory,rawScalerBank,fcupTable,slmTable,helTable,timeZone,rst,uet));
         return ret;
     }
     

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/CLASDecoder4.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/CLASDecoder4.java
@@ -5,7 +5,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import java.sql.Time;
-import java.time.ZoneId;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.jlab.detector.base.DetectorDescriptor;
@@ -47,7 +46,6 @@ public class CLASDecoder4 {
     private boolean              isRunNumberFixed = false;
     private int                  decoderDebugMode = 0;
     private SchemaFactory           schemaFactory = new SchemaFactory();
-    private ZoneId                       timeZone = ZoneId.of( "America/New_York" );
     
     public CLASDecoder4(boolean development){
         codaDecoder = new CodaEventDecoder();
@@ -631,7 +629,7 @@ public class CLASDecoder4 {
             // abort if no RCDB access (e.g. offsite)
             return ret;
         }
-        ret.addAll(DaqScalers.createBanks(schemaFactory,rawScalerBank,fcupTable,slmTable,helTable,timeZone,rst,uet));
+        ret.addAll(DaqScalers.createBanks(schemaFactory,rawScalerBank,fcupTable,slmTable,helTable,rst,uet));
         return ret;
     }
     

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScalers.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScalers.java
@@ -53,6 +53,8 @@ public class DaqScalers {
     public void setTimestamp(long timestamp) { this.timestamp=timestamp; }
     public long getTimestamp(){ return this.timestamp; }
 
+    private static final ZoneId zoneId = ZoneId.of( "America/New_York" );
+
     /**
      * Get seconds between two dates assuming the differ by not more than 24 hours.
      *
@@ -80,17 +82,16 @@ public class DaqScalers {
      * Get seconds between two times specified as a local time and a unix time
      * assuming they differ by less than 24 h
      * 
-     * @param zone run start time zone
      * @param rst  run start local local time
      * @param uet  unix event time
      * @return 
      */
-    public static double getSeconds(ZoneId zone, Time rst,long uet) {
+    public static double getSeconds(Time rst,long uet) {
         // seconds since 00:00:00, on their given day:
-        ZonedDateTime et = ZonedDateTime.ofInstant(Instant.ofEpochSecond(uet), zone);
-        ZonedDateTime st = ZonedDateTime.of(et.toLocalDate(), rst.toLocalTime(), zone);
+        ZonedDateTime et = ZonedDateTime.ofInstant(Instant.ofEpochSecond(uet), zoneId);
+        ZonedDateTime st = ZonedDateTime.of(et.toLocalDate(), rst.toLocalTime(), zoneId);
         if(st.isAfter(et)) st.minusDays(1L);
-        return (double) (et.toInstant().getEpochSecond()-st.toInstant().getEpochSecond());
+        return (double) (et.toEpochSecond()-st.toEpochSecond());
     }
 
     /**
@@ -149,8 +150,8 @@ public class DaqScalers {
      * @param uet  unix event time
      * @return 
      */
-    public static DaqScalers create(Bank rawScalerBank,IndexedTable fcupTable,IndexedTable slmTable,IndexedTable helTable,ZoneId zone,Time rst,long uet) {
-        return DaqScalers.create(rawScalerBank,fcupTable,slmTable,helTable,DaqScalers.getSeconds(zone, rst, uet));
+    public static DaqScalers create(Bank rawScalerBank,IndexedTable fcupTable,IndexedTable slmTable,IndexedTable helTable,Time rst,long uet) {
+        return DaqScalers.create(rawScalerBank,fcupTable,slmTable,helTable,DaqScalers.getSeconds(rst, uet));
     }
 
     /**
@@ -266,8 +267,8 @@ public class DaqScalers {
      * @param uet event time
      * @return [RUN::scaler,HEL::scaler] banks
      */
-    public static List<Bank> createBanks(SchemaFactory schema,Bank rawScalerBank,IndexedTable fcupTable,IndexedTable slmTable,IndexedTable helTable,ZoneId zone,Time rst,long uet) {
-        return DaqScalers.createBanks(schema,rawScalerBank,fcupTable,slmTable,helTable,DaqScalers.getSeconds(zone,rst,uet));
+    public static List<Bank> createBanks(SchemaFactory schema,Bank rawScalerBank,IndexedTable fcupTable,IndexedTable slmTable,IndexedTable helTable,Time rst,long uet) {
+        return DaqScalers.createBanks(schema,rawScalerBank,fcupTable,slmTable,helTable,DaqScalers.getSeconds(rst,uet));
     }
 
 }

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScalers.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScalers.java
@@ -1,5 +1,9 @@
 package org.jlab.detector.scalers;
 
+import java.sql.Time;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -73,6 +77,23 @@ public class DaqScalers {
     }
 
     /**
+     * Get seconds between two times specified as a local time and a unix time
+     * assuming they differ by less than 24 h
+     * 
+     * @param zone run start time zone
+     * @param rst  run start local local time
+     * @param uet  unix event time
+     * @return 
+     */
+    public static double getSeconds(ZoneId zone, Time rst,long uet) {
+        // seconds since 00:00:00, on their given day:
+        ZonedDateTime et = ZonedDateTime.ofInstant(Instant.ofEpochSecond(uet), zone);
+        ZonedDateTime st = ZonedDateTime.of(et.toLocalDate(), rst.toLocalTime(), zone);
+        if(st.isAfter(et)) st.minusDays(1L);
+        return (double) (et.toInstant().getEpochSecond()-st.toInstant().getEpochSecond());
+    }
+
+    /**
      * @param runScalerBank HIPO RUN::scaler bank
      * @return 
      */
@@ -116,6 +137,20 @@ public class DaqScalers {
      */
     public static DaqScalers create(Bank rawScalerBank,IndexedTable fcupTable,IndexedTable slmTable,IndexedTable helTable,Date rst, Date uet) {
         return DaqScalers.create(rawScalerBank,fcupTable,slmTable,helTable,DaqScalers.getSeconds(rst, uet));
+    }
+
+    /**
+     * @param rawScalerBank HIPO RAW::scaler bank
+     * @param fcupTable /runcontrol/fcup from CCDB
+     * @param slmTable /runcontrol/slm from CCDB
+     * @param helTable /runcontrol/helicity from CCDB
+     * @param zone run start time zone
+     * @param rst  run start time
+     * @param uet  unix event time
+     * @return 
+     */
+    public static DaqScalers create(Bank rawScalerBank,IndexedTable fcupTable,IndexedTable slmTable,IndexedTable helTable,ZoneId zone,Time rst,long uet) {
+        return DaqScalers.create(rawScalerBank,fcupTable,slmTable,helTable,DaqScalers.getSeconds(zone, rst, uet));
     }
 
     /**
@@ -219,6 +254,20 @@ public class DaqScalers {
      */
     public static List<Bank> createBanks(SchemaFactory schema,Bank rawScalerBank,IndexedTable fcupTable,IndexedTable slmTable,IndexedTable helTable,Date rst,Date uet) {
         return DaqScalers.createBanks(schema,rawScalerBank,fcupTable,slmTable,helTable,DaqScalers.getSeconds(rst,uet));
+    }
+
+    /**
+     * @param rawScalerBank RAW::scaler bank
+     * @param schema bank schema
+     * @param fcupTable /runcontrol/fcup CCDB table
+     * @param slmTable /runcontrol/slm CCDB table
+     * @param helTable /runcontrol/helicity CCDB table
+     * @param rst run start time
+     * @param uet event time
+     * @return [RUN::scaler,HEL::scaler] banks
+     */
+    public static List<Bank> createBanks(SchemaFactory schema,Bank rawScalerBank,IndexedTable fcupTable,IndexedTable slmTable,IndexedTable helTable,ZoneId zone,Time rst,long uet) {
+        return DaqScalers.createBanks(schema,rawScalerBank,fcupTable,slmTable,helTable,DaqScalers.getSeconds(zone,rst,uet));
     }
 
 }


### PR DESCRIPTION
Switch to using ZonedDateTime to build a date-time from the RCDB run start time and remove the dependence on the time zone that was making the FCup conversion from counts to nC dependent on the local time of the machine where the code is running. 
Since the RCDB Java API doesn't provide a date but only the local time, the assumption that remains is that the run start time is within a day from the current time. However, using ZonedDateTime.minusDays method ensures the start time date is set correctly al in case of transition from or to day-light saving. 

Tests on the last file from run 6419 that was recorded across a transition from EST to EDT show also the 1h time change is handled correctly in the calculation of the scaler integration time:

(printouts from two FCup scaler readouts
```
Run start time:	2019-03-10T00:24:49-05:00[America/New_York]
Current time:	        2019-03-10T05:15:16-04:00[America/New_York]
Integrated charge (nC):    566821.729 
Integrated time (s):       13827 
Average beam current (nA): 40.994

Run start time:	2019-03-10T00:24:49-05:00[America/New_York]
Current time:	        2019-03-10T05:15:17-04:00[America/New_York]
Integrated charge (nC):    566818.661 
Integrated time (s):       13828 
Average beam current (nA): 40.991
```
