### PR TITLE
resetting the FTCal layer read from data ADC bank to 1 for consistency with calibration constants tables

### DIFF
--- a/reconstruction/ft/src/main/java/org/jlab/rec/ft/cal/FTCALReconstruction.java
+++ b/reconstruction/ft/src/main/java/org/jlab/rec/ft/cal/FTCALReconstruction.java
@@ -213,6 +213,7 @@ public class FTCALReconstruction {
                 int icomponent  = bankDGTZ.getShort("component",row);
                 int adc         = bankDGTZ.getInt("ADC",row);
                 float time      = bankDGTZ.getFloat("time",row);
+                if(ilayer==0) ilayer=1; // fix for wrong layer in TT
                 if(adc!=-1 && time!=-1 && status.getIntValue("status", isector, ilayer, icomponent)==0){
                     FTCALHit hit = new FTCALHit(row,icomponent, adc, time, charge2Energy, timeOffsets, timeWalk, cluster);
                     


### PR DESCRIPTION
All FTCal calibration constant tables have sector-layer=1. This is consistent with the convention we have established. However the FTCal TT entries have layer=0. The only place in reconstruction where this has an effect is in reading the status table since the sector, layer, component from the adc bank are used. All the other tales are read setting manually sector=layer=1.

Since the correct values would be layer=1 and gemc is consistent with that, the fix is by setting layer to 1 before the bank is read.

