### PR TITLE
Fix CVT status reading

### DIFF
--- a/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/banks/HitReader.java
+++ b/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/banks/HitReader.java
@@ -337,6 +337,8 @@ public class HitReader {
                 if (SvtStrip.getEdep() == 0) {
                     SvtStrip.setStatus(1);
                 }
+                //get status from ccdb
+                SvtStrip.setStatus(status.getIntValue("status", sector, layer, strip));
                 // create the hit object
                 Hit hit = new Hit(DetectorType.BST, BMTType.UNDEFINED, sector, layer, SvtStrip);
                 hit.setId(id);


### PR DESCRIPTION
Fix issue with reading the CVT status table.  This is to replace iss827-CVTTrackEff-DevM5 which has an issue with merging the last commit due to squashing. 