### PR TITLE
Change conditions for termination of forward tracking iterations

### DIFF
--- a/reconstruction/dc/src/main/java/org/jlab/rec/dc/track/fit/KFitterDoca.java
+++ b/reconstruction/dc/src/main/java/org/jlab/rec/dc/track/fit/KFitterDoca.java
@@ -150,12 +150,22 @@ public class KFitterDoca {
                     i = totNumIter;
                 if (this.setFitFailed==false) {
                     if(this.finalStateVec!=null) {
-                        if(Math.abs(sv.trackTraj.get(svzLength - 1).Q-this.finalStateVec.Q)<5.e-4 &&
-                                Math.abs(sv.trackTraj.get(svzLength - 1).x-this.finalStateVec.x)<1.e-4 &&
-                                Math.abs(sv.trackTraj.get(svzLength - 1).y-this.finalStateVec.y)<1.e-4 &&
-                                Math.abs(sv.trackTraj.get(svzLength - 1).tx-this.finalStateVec.tx)<1.e-6 &&
-                                Math.abs(sv.trackTraj.get(svzLength - 1).ty-this.finalStateVec.ty)<1.e-6) {
-                            i = totNumIter;
+                        if(!TBT){
+                            if(Math.abs(sv.trackTraj.get(svzLength - 1).Q-this.finalStateVec.Q)<3.3e-3 &&
+                                    Math.abs(sv.trackTraj.get(svzLength - 1).x-this.finalStateVec.x)<7.3e-2 &&
+                                    Math.abs(sv.trackTraj.get(svzLength - 1).y-this.finalStateVec.y)<4.3e-1 &&
+                                    Math.abs(sv.trackTraj.get(svzLength - 1).tx-this.finalStateVec.tx)<9.2e-4 &&
+                                    Math.abs(sv.trackTraj.get(svzLength - 1).ty-this.finalStateVec.ty)<2.1e-3) {
+                                i = totNumIter;
+                            }
+                        }else {
+                                if (Math.abs(sv.trackTraj.get(svzLength - 1).Q - this.finalStateVec.Q) < 5.5e-5
+                                        && Math.abs(sv.trackTraj.get(svzLength - 1).x - this.finalStateVec.x) < 5.0e-4
+                                        && Math.abs(sv.trackTraj.get(svzLength - 1).y - this.finalStateVec.y) < 2.1e-3
+                                        && Math.abs(sv.trackTraj.get(svzLength - 1).tx - this.finalStateVec.tx) < 8.8e-6
+                                        && Math.abs(sv.trackTraj.get(svzLength - 1).ty - this.finalStateVec.ty) < 1.4e-5) {
+                                    i = totNumIter;
+                                } 
                         }
                     }
 


### PR DESCRIPTION
Since the conditions are too tight and all conditions need to be satisfied simultaneously, KF process reaches maximum of iterations almost for all seeds constructed by cross combination.
We should reset conditions so that cooking efficiency is improved, while tracking results are affected slightly.
[Discussion about termination of iterations for forward tracking.pdf](https://github.com/JeffersonLab/clas12-offline-software/files/10760691/Discussion.about.termination.of.iterations.for.forward.tracking.pdf)
