### PR TITLE
Remove the antiphoton test

### DIFF
--- a/validation/advanced-tests/src/eb/scripts/list.txt
+++ b/validation/advanced-tests/src/eb/scripts/list.txt
@@ -3,7 +3,6 @@ electronkaon -pid 321
 electronpion -pid 211
 electrongamma -pid 22
 electronneutron -pid 2112
-electronFTgamma -pid -22 -ft
 electrongammaFT -pid 22 -ft
 electronprotonC -pid 2212 -cd
 electronkaonC -pid 321 -cd


### PR DESCRIPTION
That should have been a +22.  But even if was, or antiphotons did exist, this test wouldn't work because of what Raffaella said, EB doesn't assign pid in the case of FT-based start time unless there's an additional charged particle in DC.

closes #1079 