### PR TITLE
Fix issue for the package org.jlab.clas.clas.math.FastMath and cache some sine and cosine calculations in DC reconstruction and forward tracking

### DIFF
--- a/common-tools/clas-math/src/main/java/org/jlab/clas/clas/math/FastMath.java
+++ b/common-tools/clas-math/src/main/java/org/jlab/clas/clas/math/FastMath.java
@@ -8,7 +8,7 @@ public class FastMath {
 	}
 
 	// controls which algorithms to use
-	private static MathLib _mathLib = MathLib.SUPERFAST;
+	private static MathLib _mathLib = MathLib.FAST;
 
 	/**
 	 * Might use standard or fast atan2

--- a/reconstruction/dc/src/main/java/org/jlab/rec/dc/Constants.java
+++ b/reconstruction/dc/src/main/java/org/jlab/rec/dc/Constants.java
@@ -48,6 +48,19 @@ public class Constants {
     private static boolean ConstantsLoaded = false;
     
     public static boolean DEBUG = false;
+    
+    // CONSTATNS for TRANSFORMATION
+    public static final double SIN25 = 0.42261826;
+    public static final double COS25 = 0.90630779;
+    public static final double COS30 = 0.86602540;  
+    public static final double SIN6 = 0.10452846;
+    public static final double COS6 = 0.99452190;
+    public static final double TAN6 = 0.10510424;
+    public static final double CTAN6 = 9.51436445;
+    public static final double[] SINSECTOR60 = {0, 0.86602540, 0.86602540, 0, -0.86602540, -0.86602540};
+    public static final double[] COSSECTOR60 = {1, 0.5, -0.5, -1, -0.5, 0.5};
+    public static final double[] SINSECTORNEG60 = {0, -0.86602540, -0.86602540, 0, 0.86602540, 0.86602540};
+    public static final double[] COSSECTORNEG60 = {1, 0.5, -0.5, -1, -0.5, 0.5};
 
     // PHYSICS CONSTANTS
     public static final double SPEEDLIGHT = 29.97924580;

--- a/reconstruction/dc/src/main/java/org/jlab/rec/dc/Constants.java
+++ b/reconstruction/dc/src/main/java/org/jlab/rec/dc/Constants.java
@@ -17,6 +17,7 @@ import org.jlab.detector.calib.utils.ConstantsManager;
 import org.jlab.geom.base.Detector;
 import org.jlab.rec.dc.trajectory.TrajectorySurfaces;
 import org.jlab.utils.groups.IndexedTable;
+import org.jlab.clas.clas.math.FastMath;
 
 /**
  * Constants used in the reconstruction
@@ -50,18 +51,20 @@ public class Constants {
     public static boolean DEBUG = false;
     
     // CONSTATNS for TRANSFORMATION
-    public static final double SIN25 = 0.42261826;
-    public static final double COS25 = 0.90630779;
-    public static final double COS30 = 0.86602540;  
-    public static final double SIN6 = 0.10452846;
-    public static final double COS6 = 0.99452190;
-    public static final double TAN6 = 0.10510424;
-    public static final double CTAN6 = 9.51436445;
-    public static final double[] SINSECTOR60 = {0, 0.86602540, 0.86602540, 0, -0.86602540, -0.86602540};
+    public static final double SIN25 = FastMath.sin(Math.toRadians(25.));
+    public static final double COS25 = FastMath.cos(Math.toRadians(25.));
+    public static final double COS30 = FastMath.cos(Math.toRadians(30.));
+    public static final double SIN6 = FastMath.sin(Math.toRadians(6.));
+    public static final double COS6 = FastMath.cos(Math.toRadians(6.));
+    public static final double TAN6 = Math.tan(Math.toRadians(6.));
+    public static final double CTAN6 = 1 / TAN6;
+    public static final double[] SINSECTOR60 = {0, FastMath.sin(Math.toRadians(60.)), FastMath.sin(Math.toRadians(120.)), 0,
+        FastMath.sin(Math.toRadians(240.)), FastMath.sin(Math.toRadians(300.))};
     public static final double[] COSSECTOR60 = {1, 0.5, -0.5, -1, -0.5, 0.5};
-    public static final double[] SINSECTORNEG60 = {0, -0.86602540, -0.86602540, 0, 0.86602540, 0.86602540};
+    public static final double[] SINSECTORNEG60 = {0, FastMath.sin(Math.toRadians(-60.)), FastMath.sin(Math.toRadians(-120.)), 0,
+        FastMath.sin(Math.toRadians(-240.)), FastMath.sin(Math.toRadians(-300.))};
     public static final double[] COSSECTORNEG60 = {1, 0.5, -0.5, -1, -0.5, 0.5};
-
+       
     // PHYSICS CONSTANTS
     public static final double SPEEDLIGHT = 29.97924580;
     public static final double LIGHTVEL = 0.00299792458;        // velocity of light (cm/ns) - conversion factor from radius in cm to momentum in GeV/c

--- a/reconstruction/dc/src/main/java/org/jlab/rec/dc/cluster/ClusterFitter.java
+++ b/reconstruction/dc/src/main/java/org/jlab/rec/dc/cluster/ClusterFitter.java
@@ -12,6 +12,7 @@ import org.jlab.geom.prim.Vector3D;
 import org.jlab.rec.dc.hit.FittedHit;
 import org.jlab.rec.dc.track.fit.basefit.LineFitPars;
 import org.jlab.rec.dc.track.fit.basefit.LineFitter;
+import org.jlab.rec.dc.Constants; 
 
 public class ClusterFitter {
 
@@ -26,7 +27,7 @@ public class ClusterFitter {
     private final List<Double> y = new ArrayList<Double>();
     private final List<Double> ex = new ArrayList<Double>();
     private final List<Double> ey = new ArrayList<Double>();
-    private final double stereo = FastMath.cos(Math.toRadians(6.));
+    private final double stereo = Constants.COS6;
     
     private String CoordinateSystem; // LC= local, TSC = tilted Sector
     public ClusterFitter() {

--- a/reconstruction/dc/src/main/java/org/jlab/rec/dc/cross/Cross.java
+++ b/reconstruction/dc/src/main/java/org/jlab/rec/dc/cross/Cross.java
@@ -10,6 +10,7 @@ import org.jlab.detector.geant4.v2.DCGeant4Factory;
 import org.jlab.geom.prim.Point3D;
 import org.jlab.rec.dc.hit.FittedHit;
 import org.jlab.rec.dc.segment.Segment;
+import org.jlab.rec.dc.Constants;
 
 /**
  * The crosses are objects used to find tracks and are characterized by a 3-D
@@ -46,10 +47,7 @@ public class Cross extends ArrayList<Segment> implements Comparable<Cross> {
     private Segment _seg1;
     private Segment _seg2;
     public boolean isPseudoCross = false;
-    
-    private final double cos_tilt = FastMath.cos(Math.toRadians(25.));
-    private final double sin_tilt = FastMath.sin(Math.toRadians(25.));
-    
+       
     public int recalc;
     /**
      *
@@ -261,7 +259,7 @@ public class Cross extends ArrayList<Segment> implements Comparable<Cross> {
         //double z = GeometryLoader.dcDetector.getSector(0).getRegionMiddlePlane(this.get_Region()-1).point().z();
         double z = DcDetector.getRegionMidpoint(this.get_Region() - 1).z;
 
-        double wy_over_wx = (Math.cos(Math.toRadians(6.)) / Math.sin(Math.toRadians(6.)));
+        double wy_over_wx = Constants.CTAN6;
         double val_sl1 = this._seg1.get_fittedCluster().get_clusterLineFitSlope();
         double val_sl2 = this._seg2.get_fittedCluster().get_clusterLineFitSlope();
         double val_it1 = this._seg1.get_fittedCluster().get_clusterLineFitIntercept();
@@ -344,9 +342,9 @@ public class Cross extends ArrayList<Segment> implements Comparable<Cross> {
      * @return rotated coords from tilted sector coordinate system to the sector
      * coordinate system
      */
-    public Point3D getCoordsInSector(double X, double Y, double Z) {
-        double rz = -X * sin_tilt + Z * cos_tilt;
-        double rx = X * cos_tilt + Z * sin_tilt;
+    public Point3D getCoordsInSector(double X, double Y, double Z) {        
+        double rz = -X * Constants.SIN25 + Z * Constants.COS25;
+        double rx = X * Constants.COS25 + Z * Constants.SIN25;
 
         return new Point3D(rx, Y, rz);
     }
@@ -360,19 +358,19 @@ public class Cross extends ArrayList<Segment> implements Comparable<Cross> {
      * frame
      */
     public Point3D getCoordsInLab(double X, double Y, double Z) {
-        Point3D PointInSec = this.getCoordsInSector(X, Y, Z);
-        double rx = PointInSec.x() * FastMath.cos((this.get_Sector() - 1) * Math.toRadians(60.)) - PointInSec.y() * FastMath.sin((this.get_Sector() - 1) * Math.toRadians(60.));
-        double ry = PointInSec.x() * FastMath.sin((this.get_Sector() - 1) * Math.toRadians(60.)) + PointInSec.y() * FastMath.cos((this.get_Sector() - 1) * Math.toRadians(60.));
+        Point3D PointInSec = this.getCoordsInSector(X, Y, Z);                
+        double rx = PointInSec.x() * Constants.COSSECTOR60[this.get_Sector() - 1] - PointInSec.y() * Constants.SINSECTOR60[this.get_Sector() - 1];
+        double ry = PointInSec.x() * Constants.SINSECTOR60[this.get_Sector() - 1] + PointInSec.y() * Constants.COSSECTOR60[this.get_Sector() - 1];
 
         return new Point3D(rx, ry, PointInSec.z());
     }
     
-    public Point3D getCoordsInTiltedSector(double X, double Y, double Z) {
-        double rx = X * FastMath.cos((this.get_Sector() - 1) * Math.toRadians(-60.)) - Y * FastMath.sin((this.get_Sector() - 1) * Math.toRadians(-60.));
-        double ry = X * FastMath.sin((this.get_Sector() - 1) * Math.toRadians(-60.)) + Y * FastMath.cos((this.get_Sector() - 1) * Math.toRadians(-60.));
-       
-        double rtz = rx * sin_tilt + Z * cos_tilt;
-        double rtx = rx * cos_tilt - Z * sin_tilt;
+    public Point3D getCoordsInTiltedSector(double X, double Y, double Z) {        
+        double rx = X * Constants.COSSECTORNEG60[this.get_Sector() - 1] - Y * Constants.SINSECTORNEG60[this.get_Sector() - 1];
+        double ry = X * Constants.SINSECTORNEG60[this.get_Sector() - 1] + Y * Constants.COSSECTORNEG60[this.get_Sector() - 1];
+               
+        double rtz = rx * Constants.SIN25 + Z * Constants.COS25;
+        double rtx = rx * Constants.COS25 - Z * Constants.SIN25;
          
         return new Point3D(rtx, ry, rtz);
     }
@@ -405,7 +403,7 @@ public class Cross extends ArrayList<Segment> implements Comparable<Cross> {
      */
 
     public void set_CrossDirIntersSegWires() {
-        double wy_over_wx = (FastMath.cos(Math.toRadians(6.)) / FastMath.sin(Math.toRadians(6.)));
+        double wy_over_wx = Constants.CTAN6;
         double val_sl1 = this._seg1.get_fittedCluster().get_clusterLineFitSlope();
         double val_sl2 = this._seg2.get_fittedCluster().get_clusterLineFitSlope();
         double val_it1 = this._seg1.get_fittedCluster().get_clusterLineFitIntercept();

--- a/reconstruction/dc/src/main/java/org/jlab/rec/dc/hit/FittedHit.java
+++ b/reconstruction/dc/src/main/java/org/jlab/rec/dc/hit/FittedHit.java
@@ -666,7 +666,7 @@ public class FittedHit extends Hit implements Comparable<Hit> {
                 throw new RuntimeException("invalid region");
         }    
         
-        double MaxSag = Constants.getInstance().getWIREDIST()*A*C*wire*wire*FastMath.cos(Math.toRadians(25.))*FastMath.cos(Math.toRadians(30.));
+        double MaxSag = Constants.getInstance().getWIREDIST()*A*C*wire*wire*Constants.COS25*Constants.COS30;
 
         double delta_x = MaxSag*(1.-Math.abs(y)/(0.5*wireLen))*(1.-Math.abs(y)/(0.5*wireLen));
         

--- a/reconstruction/dc/src/main/java/org/jlab/rec/dc/segment/Segment.java
+++ b/reconstruction/dc/src/main/java/org/jlab/rec/dc/segment/Segment.java
@@ -286,16 +286,16 @@ public class Segment extends ArrayList<FittedHit> implements Comparable<Segment>
         //double Z_1 = GeometryLoader.dcDetector.getSector(0).getSuperlayer(this.get_Superlayer()-1).getLayer(0).getComponent(0).getMidpoint().z();
         double Z_1 = DcDetector.getWireMidpoint(this.get_Sector() - 1, this.get_Superlayer() - 1, 0, 0).z;
         double X_1 = this.get_fittedCluster().get_clusterLineFitSlope() * Z_1 + this.get_fittedCluster().get_clusterLineFitIntercept();
-
-        double x1 = FastMath.cos(Math.toRadians(25.)) * X_1 + FastMath.sin(Math.toRadians(25.)) * Z_1;
-        double z1 = -FastMath.sin(Math.toRadians(25.)) * X_1 + FastMath.cos(Math.toRadians(25.)) * Z_1;
+        
+        double x1 = Constants.COS25 * X_1 + Constants.SIN25 * Z_1;
+        double z1 = -Constants.SIN25 * X_1 + Constants.COS25 * Z_1;
 
         //double Z_2 = GeometryLoader.dcDetector.getSector(0).getSuperlayer(this.get_Superlayer()-1).getLayer(5).getComponent(0).getMidpoint().z();
         double Z_2 = DcDetector.getWireMidpoint(this.get_Sector() - 1, this.get_Superlayer() - 1, 5, 0).z;
         double X_2 = this.get_fittedCluster().get_clusterLineFitSlope() * Z_2 + this.get_fittedCluster().get_clusterLineFitIntercept();
-
-        double x2 = FastMath.cos(Math.toRadians(25.)) * X_2 + FastMath.sin(Math.toRadians(25.)) * Z_2;
-        double z2 = -FastMath.sin(Math.toRadians(25.)) * X_2 + FastMath.cos(Math.toRadians(25.)) * Z_2;
+        
+        double x2 = Constants.COS25 * X_2 + Constants.SIN25 * Z_2;
+        double z2 = -Constants.SIN25 * X_2 + Constants.COS25 * Z_2;
 
         double[] EndPointsArray = new double[4];
         EndPointsArray[0] = x1;
@@ -349,9 +349,9 @@ public class Segment extends ArrayList<FittedHit> implements Comparable<Segment>
      * by a point on the plane and a unit normal vector.
      */
     private Plane3D calc_fitPlane(Point3D refPoint, Vector3D refDir) {
-
-        double X = Math.pow(-1, (this.get_Superlayer() - 1)) * FastMath.sin(Math.toRadians(6));
-        double Y = FastMath.cos(Math.toRadians(6.));
+        
+        double X = Math.pow(-1, (this.get_Superlayer() - 1)) * Constants.SIN6;
+        double Y = Constants.COS6;
 
         Vector3D plDir = new Vector3D(X, Y, 0);
 

--- a/reconstruction/dc/src/main/java/org/jlab/rec/dc/segment/SegmentFinder.java
+++ b/reconstruction/dc/src/main/java/org/jlab/rec/dc/segment/SegmentFinder.java
@@ -84,7 +84,7 @@ public class SegmentFinder {
                     int trjWire = trj.getWireOnTrajectory(seg.get_Sector(), seg.get_Superlayer(), l + 1, trkXMP, DcDetector);
                     //double x = GeometryLoader.dcDetector.getSector(0).getSuperlayer(seg.get_Superlayer()-1).getLayer(l).getComponent(trjWire-1).getMidpoint().x();
                     double x = DcDetector.getWireMidpoint(seg.get_Sector() - 1, seg.get_Superlayer() - 1, l, trjWire - 1).x;
-                    double cosTkAng = FastMath.cos(Math.toRadians(6.)) * Math.sqrt(1. + seg.get_fittedCluster().get_clusterLineFitSlope() * seg.get_fittedCluster().get_clusterLineFitSlope());
+                    double cosTkAng = Constants.COS6 * Math.sqrt(1. + seg.get_fittedCluster().get_clusterLineFitSlope() * seg.get_fittedCluster().get_clusterLineFitSlope());
                     double calc_doca = (x - trkX) * cosTkAng;
                     trkDocas[l] = calc_doca;
 

--- a/reconstruction/dc/src/main/java/org/jlab/rec/dc/track/fit/StateVecsDoca.java
+++ b/reconstruction/dc/src/main/java/org/jlab/rec/dc/track/fit/StateVecsDoca.java
@@ -374,7 +374,7 @@ public class StateVecsDoca {
         double err_sl2 = trkcand.get(0).get_Segment2().get_fittedCluster().get_clusterLineFitSlopeErr();
         double err_it1 = trkcand.get(0).get_Segment1().get_fittedCluster().get_clusterLineFitInterceptErr();
         double err_it2 = trkcand.get(0).get_Segment2().get_fittedCluster().get_clusterLineFitInterceptErr();
-        double wy_over_wx = (FastMath.cos(Math.toRadians(6.)) / FastMath.sin(Math.toRadians(6.)));
+        double wy_over_wx = Constants.CTAN6;
 
         double eux = 0.5 * Math.sqrt(err_sl1 * err_sl1 + err_sl2 * err_sl2);
         double euy = 0.5 * wy_over_wx * Math.sqrt(err_sl1 * err_sl1 + err_sl2 * err_sl2);

--- a/reconstruction/dc/src/main/java/org/jlab/rec/dc/trajectory/RoadFinder.java
+++ b/reconstruction/dc/src/main/java/org/jlab/rec/dc/trajectory/RoadFinder.java
@@ -9,6 +9,7 @@ import org.jlab.rec.dc.cluster.ClusterFitter;
 import org.jlab.rec.dc.cluster.FittedCluster;
 import org.jlab.rec.dc.hit.FittedHit;
 import org.jlab.rec.dc.segment.Segment;
+import org.jlab.rec.dc.Constants;
 
 import Jama.Matrix;
 import org.jlab.detector.geant4.v2.DCGeant4Factory;
@@ -168,12 +169,12 @@ public class RoadFinder  {
             int layer = l+1;
             double z = DcDetector.getWireMidpoint(pseudoSeg.get_Sector()-1, pseudoSeg.get_Superlayer()-1,layer-1,0).z;
             double trkX = qf.a[0]*z*z+qf.a[1]*z+qf.a[2]; 
-            double delta = (trkX-pseudoSeg.get(l).get_X())/pseudoSeg.get(l).get_CellSize()/FastMath.cos(Math.toRadians(6.)) ;
+            double delta = (trkX-pseudoSeg.get(l).get_X())/pseudoSeg.get(l).get_CellSize()/Constants.COS6 ;
             int calcWire = segTrj.getWireOnTrajectory(pseudoSeg.get_Sector(), pseudoSeg.get_Superlayer(), layer, trkX, DcDetector);
 
             FittedHit pseudoHit = new FittedHit(segList.get(0).get_Sector(),pseudoSeg.get_Superlayer(), layer, calcWire,
                             0, 0, -1); 
-            pseudoHit.set_DocaErr(pseudoHit.get_CellSize()/Math.sqrt(12.)/FastMath.cos(Math.toRadians(6.)));
+            pseudoHit.set_DocaErr(pseudoHit.get_CellSize()/Math.sqrt(12.)/Constants.COS6);
             pseudoHit.updateHitPosition(DcDetector);
             pseudoHit.calc_GeomCorr(DcDetector, 0);
             fpseudoCluster.add(pseudoHit);
@@ -209,8 +210,8 @@ public class RoadFinder  {
                 X[hitno] = s.get(j).get_X();
                 //X[hitno] = GeometryLoader.dcDetector.getSector(0).getSuperlayer(s.get(j).get_Superlayer()-1).getLayer(s.get(j).get_Layer()-1).getComponent(s.get(j).get_Wire()-1).getMidpoint().x();
                 Z[hitno] = s.get(j).get_Z();
-                //errX[hitno] = s.get(j).get_DocaErr()/FastMath.cos(Math.toRadians(6.)); 
-                errX[hitno] = s.get(j).get_CellSize()/Math.sqrt(12.)/FastMath.cos(Math.toRadians(6.)); 
+                //errX[hitno] = s.get(j).get_DocaErr()/Constants.COS6; 
+                errX[hitno] = s.get(j).get_CellSize()/Math.sqrt(12.)/Constants.COS6; 
                 hitno++;
             }
         }

--- a/reconstruction/dc/src/main/java/org/jlab/rec/dc/trajectory/TrackVec.java
+++ b/reconstruction/dc/src/main/java/org/jlab/rec/dc/trajectory/TrackVec.java
@@ -2,6 +2,7 @@ package org.jlab.rec.dc.trajectory;
 
 import Jama.*;
 import org.jlab.clas.clas.math.FastMath;
+import org.jlab.rec.dc.Constants;
 /**
  * Describes a track pars in the DC.  
  * @author ziegler
@@ -227,9 +228,9 @@ public class TrackVec extends Matrix {
      * @param t <0 going to lab, >0 going to tilted system
      * @return 
      */
-    public double[] tilt(double X, double Z, int t) {
-        double rz = (double)t *X * sin_tilt + Z * cos_tilt;
-        double rx = X * cos_tilt -(double)t* Z * sin_tilt;
+    public double[] tilt(double X, double Z, int t) {        
+        double rz = (double)t *X * Constants.SIN25 + Z * Constants.COS25;
+        double rx = X * Constants.COS25 -(double)t* Z * Constants.SIN25;
         
         return new double[] {rx, rz};
     }
@@ -243,10 +244,15 @@ public class TrackVec extends Matrix {
      */
     public double[] rotateToSec(int sector, double x, double y, int t) {
         if(sector>0 && sector<7) {
-            double rx = x * FastMath.cos((sector - 1) * t*rad60) - y * FastMath.sin((sector - 1) * t*rad60);
-            double ry = x * FastMath.sin((sector - 1) * t*rad60) + y * FastMath.cos((sector - 1) * t*rad60);
-            
-            return new double[] {rx, ry};
+            if (t == 1) {
+                double rx = x * Constants.COSSECTOR60[sector - 1] - y * Constants.SINSECTOR60[sector - 1];
+                double ry = x * Constants.SINSECTOR60[sector - 1] + y * Constants.COSSECTOR60[sector - 1];
+                return new double[]{rx, ry};
+            } else {
+                double rx = x * Constants.COSSECTORNEG60[sector - 1] - y * Constants.SINSECTORNEG60[sector - 1];
+                double ry = x * Constants.SINSECTORNEG60[sector - 1] + y * Constants.COSSECTORNEG60[sector - 1];
+                return new double[]{rx, ry};
+            }            
         } else {
             return null;
         }
@@ -283,26 +289,4 @@ public class TrackVec extends Matrix {
         }
         return sector;
     }
-    private final double cos_tilt = FastMath.cos(Math.toRadians(25.));
-    private final double sin_tilt = FastMath.sin(Math.toRadians(25.));
-    
-    private final double rad60 = Math.toRadians(60.);
-    /*
-    public Point3D getCoordsInLab(double X, double Y, double Z) {
-        Point3D PointInSec = this.getCoordsInSector(X, Y, Z);
-        double rx = PointInSec.x() * FastMath.cos((this.get_Sector() - 1) * Math.toRadians(60.)) - PointInSec.y() * FastMath.sin((this.get_Sector() - 1) * Math.toRadians(60.));
-        double ry = PointInSec.x() * FastMath.sin((this.get_Sector() - 1) * Math.toRadians(60.)) + PointInSec.y() * FastMath.cos((this.get_Sector() - 1) * Math.toRadians(60.));
-
-        return new Point3D(rx, ry, PointInSec.z());
-    }
-    
-    public Point3D getCoordsInTiltedSector(double X, double Y, double Z) {
-        double rx = X * FastMath.cos((this.get_Sector() - 1) * Math.toRadians(-60.)) - Y * FastMath.sin((this.get_Sector() - 1) * Math.toRadians(-60.));
-        double ry = X * FastMath.sin((this.get_Sector() - 1) * Math.toRadians(-60.)) + Y * FastMath.cos((this.get_Sector() - 1) * Math.toRadians(-60.));
-       
-        double rtz = rx * sin_tilt + Z * cos_tilt;
-        double rtx = rx * cos_tilt - Z * sin_tilt;
-         
-        return new Point3D(rtx, ry, rtz);
-    */
 }


### PR DESCRIPTION
Overall, there are two updates for this PR:
1) Fix issue for the package org.jlab.clas.clas.math.FastMath
The file describes the issue, and effects on tracking results.
[issue for the package FastMath.pdf](https://github.com/JeffersonLab/clas12-offline-software/files/10903247/issue.for.the.package.FastMath.pdf)
2) Cache sine and cosine calculations in DC reconstruction and forward tracking
It will not affect tracking results, but will save running time.
As expected, the plots shows that changes due to precision of float for tracking results is negligible.
[diff of RECParticle.pdf](https://github.com/JeffersonLab/clas12-offline-software/files/10903290/diff.of.RECParticle.pdf)

The update 1 increases running time, while the update 2 reduces running time. As my quick test, the running time with the two updates almost has no change comparing to before updates.